### PR TITLE
Map ol fix mapstate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 
 ### Bug Fixes
 * **demo-maps:** Set routing to HashLocationStrategy and fix update Search Params on MapState change example.
+* **@dlr-eoc/map-ol:** Subscribe to map state before map creation, then set this state on AfterViewInit so if `mapStateSvc.setMapState` or `mapStateSvc.setExtent` is triggered from a View/Route in ngOnInit the state is set correctly.
 
 
 ### Changes
 * **update dependencies** angular, clarity, ol, proj4
+* **@dlr-eoc/services-map-state:** Create new instances on set state and remove the not needed extent Subject.
 
 
 ### Features
- * **@dlr-eoc/layer-control:** Adjust layerentry so it can use a Angular Component in the settings and as legend #12 #13. 
- * **@dlr-eoc/services-layers:** Adjust layer types so it can use a Angular Component for `action` or `legendImg` #12 #13. 
- * **@dlr-eoc/core-ui:** Export DynamicComponent and ViewRefDirective
- * **@dlr-eoc/services-layers:** RasterLayers can now specify the parameter `crossOrigin` in their constructor. 
+* **@dlr-eoc/map-tools:** Allow map navigator to set the input step.
+* **@dlr-eoc/services-map-state:** Add function to get the last action of the MapStateService so if a full state was set or only the extent.
+* **@dlr-eoc/layer-control:** Adjust layerentry so it can use a Angular Component in the settings and as legend #12 #13. 
+* **@dlr-eoc/services-layers:** Adjust layer types so it can use a Angular Component for `action` or `legendImg` #12 #13. 
+* **@dlr-eoc/core-ui:** Export DynamicComponent and ViewRefDirective
+* **@dlr-eoc/services-layers:** RasterLayers can now specify the parameter `crossOrigin` in their constructor. 
 
 
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 
 ### Changes
+* **@dlr-eoc/map-ol:** The function mapOnMoveend now set the MapState without rounding the values for zoom and center.
 * **update dependencies** angular, clarity, ol, proj4
 * **@dlr-eoc/services-map-state:** Create new instances on set state and remove the not needed extent Subject.
 

--- a/projects/demo-maps/src/app/route-components/route-example-events/route-map3.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-events/route-map3.component.ts
@@ -48,7 +48,6 @@ export class RouteMap3Component implements OnInit, AfterViewInit, OnDestroy {
     this.subscribeToMapState();
     this.subscribeToRoute();
     if (this.startBbox) {
-      console.log('this.startBbox', this.startBbox)
       this.mapStateSvc.setExtent(this.startBbox);
     }
   }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -77,7 +77,7 @@ export class MapOlService {
 
   /** USED in map-ol.component */
   public createMap(target?: HTMLElement) {
-    const zoom = 3;
+    const zoom = 0;
     const center = {
       lat: 0,
       lon: 0

--- a/projects/map-tools/src/lib/navigator/map-navigator.component.html
+++ b/projects/map-tools/src/lib/navigator/map-navigator.component.html
@@ -1,18 +1,33 @@
-<div>
-  <form clrForm class="input-container">
-    <clr-input-container>
-      <label>Lon</label>
-      <input clrInput type="number" [(ngModel)]="mapstate.center.lon" name="lon" [step]="inputStep"
-        (ngModelChange)="stateChange($event)">/>
-    </clr-input-container>
-    <clr-input-container>
-      <label>Lat</label>
-      <input clrInput type="number" [(ngModel)]="mapstate.center.lat" name="lat" [step]="inputStep"
-        (ngModelChange)="stateChange($event)">/>
-    </clr-input-container>
-    <clr-input-container>
-      <label>Zoom</label>
-      <input clrInput type="number" [(ngModel)]="mapstate.zoom" name="zoom" (ngModelChange)="stateChange($event)">/>
-    </clr-input-container>
-  </form>
+<div class="clr-row">
+  <div class="clr-col-9">
+    <div class="output-container">
+      <form clrForm>
+        <!-- class="input-container" -->
+        <clr-input-container>
+          <label>Lon</label>
+          <input clrInput type="number" [(ngModel)]="mapstate.center.lon" name="lon" [step]="inputStep"
+            (ngModelChange)="stateChange($event)" />
+        </clr-input-container>
+        <clr-input-container>
+          <label>Lat</label>
+          <input clrInput type="number" [(ngModel)]="mapstate.center.lat" name="lat" [step]="inputStep"
+            (ngModelChange)="stateChange($event)" />
+        </clr-input-container>
+        <clr-input-container>
+          <label>Zoom</label>
+          <input clrInput type="number" [(ngModel)]="mapstate.zoom" name="zoom" [step]="inputStep"
+            (ngModelChange)="stateChange($event)" />
+        </clr-input-container>
+      </form>
+    </div>
+  </div>
+  <div class="clr-col-3">
+    <div class="input-container">
+      <clr-input-container>
+        <label>Precision </label>
+        <input type="number" min="0" max="8" step="1" [(ngModel)]="precision" (ngModelChange)="setInputStep($event)"
+          name="precision" clrInput />
+      </clr-input-container>
+    </div>
+  </div>
 </div>

--- a/projects/map-tools/src/lib/navigator/map-navigator.component.scss
+++ b/projects/map-tools/src/lib/navigator/map-navigator.component.scss
@@ -1,5 +1,11 @@
-.input-container {
+.output-container {
   & .clr-form-control:first-child {
     margin-top: 0rem;
+  }
+}
+
+.output-container {
+  .clr-input {
+    width: 90%;
   }
 }

--- a/projects/map-tools/src/lib/navigator/map-navigator.component.ts
+++ b/projects/map-tools/src/lib/navigator/map-navigator.component.ts
@@ -13,6 +13,7 @@ export class MapNavigatorComponent implements OnInit, OnDestroy {
   mapstate: MapState;
   subscription: Subscription;
   public inputStep = 0.01;
+  public precision = 2;
   constructor() { }
 
   ngOnInit() {
@@ -37,8 +38,17 @@ export class MapNavigatorComponent implements OnInit, OnDestroy {
     this.mapState.setMapState(newstate);
   }
 
-  stateChange(ev) {
+  stateChange(evt) {
     this.setNewState(this.mapstate);
+  }
+
+  setInputStep(evt: number) {
+    const value = Array.from(Array(evt), (_, x) => '0').join('');
+    this.inputStep = 1 / Number(`1${value}`);
+  }
+
+  public toPrecision(input: number, value: number) {
+    return input.toFixed(value);
   }
 
 }

--- a/projects/services-map-state/src/lib/map-state.service.spec.ts
+++ b/projects/services-map-state/src/lib/map-state.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, async } from '@angular/core/testing';
 import { MapStateService } from './map-state.service';
-import { MapState, TGeoExtent } from './types/map-state';
+import { MapState, TGeoExtent, IMapState } from './types/map-state';
 
 describe('MapStateService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
@@ -11,17 +11,17 @@ describe('MapStateService', () => {
   });
 
 
-  it('should get the MapState', async(() => {
+  it('should get the initial MapState', async(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
     service.getMapState().subscribe((state) => {
       expect(state.center.lat).toEqual(0);
       expect(state.center.lon).toEqual(0);
-      expect(state.zoom).toEqual(12);
+      expect(state.zoom).toEqual(0);
     });
   }));
 
 
-  it('should set the MapState', async(() => {
+  it('should set/get the MapState', async(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
     const state = new MapState(4, { lat: 48, lon: 11 });
 
@@ -34,9 +34,8 @@ describe('MapStateService', () => {
   }));
 
 
-  it('should get the current Extent', async(() => {
+  it('should get the initial Extent', async(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
-
     service.getExtent().subscribe((ext) => {
       expect(ext[0]).toEqual(-180);
       expect(ext[1]).toEqual(-90);
@@ -45,7 +44,7 @@ describe('MapStateService', () => {
     });
   }));
 
-  it('should set the current Extent', async(() => {
+  it('should set/get the current Extent', async(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
     const extent: TGeoExtent = [-10, -10, 10, 10];
 
@@ -57,5 +56,30 @@ describe('MapStateService', () => {
       expect(ext[3]).toEqual(10);
     });
   }));
+
+
+  it('should compare state Extent and Center', async(() => {
+    const extent: TGeoExtent = [5.075658586129323, 36.56406504906195, 36.05016620655786, 56.96174826062932];
+    const center: IMapState['center'] = { lat: 47.750279, lon: 20.562912 };
+    const state = new MapState(5, center, { notifier: 'map' }, extent);
+
+    const extent2: TGeoExtent = [31.672061198984096, 42.86439737465432, 47.15931500919837, 52.97431681666987];
+    const center2: IMapState['center'] = { lat: 48.167712, lon: 39.415688 };
+    const state2 = new MapState(6, center2, { notifier: 'user' }, extent2);
+
+    expect(state.sameExtent(state.extent)).toBe(true);
+    expect(state.sameCenter(state.center)).toBe(true);
+    expect(state.sameZoom(state.zoom)).toBe(true);
+    expect(state.sameNotifier(state.options.notifier)).toBe(true);
+
+
+    expect(state.sameExtent(state2.extent)).toBe(false);
+    expect(state.sameCenter(state2.center)).toBe(false);
+    expect(state.sameZoom(state2.zoom)).toBe(false);
+    expect(state.sameNotifier(state2.options.notifier)).toBe(false);
+  }));
+
+
+
 });
 

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -34,19 +34,50 @@ export class MapState implements IMapState {
   /** iso 8601 Datestring */
   time: string;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent?: TGeoExtent, time?: string) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], time: string = new Date().toISOString()) {
+    const defaultOptions = {
+      maxzoom: 0,
+      minzoom: 0,
+      notifier: 'map'
+    };
     this.zoom = zoom;
     this.center = center;
-    this.extent = extent || [-180.0, -90.0, 180.0, 90.0];
-    this.time = time || new Date().toISOString();
-    if (options) {
-      this.options = options;
+    this.extent = extent;
+    this.time = time;
+    this.options = Object.assign(defaultOptions, options);
+  }
+
+
+  public sameCenter(center: IMapState['center']) {
+    if (this.center.lat === center.lat && this.center.lon === center.lon) {
+      return true;
     } else {
-      this.options = {
-        maxzoom: 0,
-        minzoom: 0,
-        notifier: 'map'
-      };
+      return false;
+    }
+  }
+
+  public sameZoom(zoom: IMapState['zoom']) {
+    if (this.zoom === zoom) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public sameExtent(extent: TGeoExtent) {
+    const len = extent.length;
+    let isSame = false;
+    if (this.extent.length === len) {
+      isSame = this.extent.every((v, i) => extent[i] === v);
+    }
+    return isSame;
+  }
+
+  public sameNotifier(notifier: IMapState['options']['notifier']) {
+    if (this.options.notifier === notifier) {
+      return true;
+    } else {
+      return false;
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
- If a user want to set the map center and zoom or extent with the `MapStateService`, it is not possible on component `OnInit`(e.g. in a route component) because the registration to the observable in the map-ol component is later (`AfterViewInit`).


## What is the new behavior?
- Now the registration to the `MapStateService` in the map-ol component is on `OnInit` and after this the last value which was set is used to set ol/view which is only available `AfterViewInit`.
So it is possible now to set the `MapState` in a route component on `OnInit` or from url parameters.

- The MapStateService now provides a method `getLastAction()` so it is possible to check if a full State object was set or only the extent.
This is useful because we can not calculate the zoom and center from extent and vice versa, this is then done by the ol/map itself and after this the `MapState` is set internaly from the application so it includes both extent and center/zoom.
This complicated Structure is because we wanted to be the `MapStateService` map library independent!

- Furthermore the [map-navigator](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/master/projects/map-tools) was adjusted to set the input step for navigation.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?

@dlr-eoc/map-ol
@dlr-eoc/map-tools
@dlr-eoc/services-map-state
demo-maps
