### PR TITLE
ci: fix github action download-artifact changed

### DIFF
--- a/.github/workflows/nodejsPackage.yml
+++ b/.github/workflows/nodejsPackage.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
          name: "dist"
+         path: dist
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -53,6 +54,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: "dist"
+          path: dist
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -74,6 +76,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: "dist"
+          path: dist
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The GitHub Action `download-artifact@v2` [no longer adds an extra root directory](https://github.blog/changelog/2020-01-14-github-actions-changes-to-artifact-download-experience/) to the downloaded archive so there is no folder dist to work with later on. Therefore [set versions in dist](https://github.com/dlr-eoc/ukis-frontend-libraries/runs/1050861354?check_suite_focus=true#step:6:8) is not working correctly and the [job to publish packages](https://github.com/dlr-eoc/ukis-frontend-libraries/runs/1050870425?check_suite_focus=true) fails because there is no dist folder.


## What is the new behavior?
Fixes the CI Issues and finally published package with the tag v7.2.0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
