### PR TITLE
Fix: Do not automatically zoom in on a Cluster in if Popup event move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Bug Fixes
-* **@dlr-eoc/map-ol:** 
+* **@dlr-eoc/map-ol:**
+  - Do not automatically zoom in on Clusters if Popup event is move.
   - reuse popup on move [12f77a80](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/50/commits/12f77a80dc333471be3ea6431a21e6bcbeed487f) [#47](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/47)
   - getLayerByKey() not working on layergroups (recursive).
   - removeLayerByKey() not working on layergroups (recursive).

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1240,15 +1240,25 @@ export class MapOlService {
             const childFeature = childFeatures[0];
             properties = childFeature.getProperties();
           } else if (childFeatures && childFeatures.length > 1) {
-            const extent = this.getFeaturesExtent(feature.getProperties().features);
-            this.setExtent(extent);
-            return false;
+            /** or check for layerpopup.event !== move */
+            if (evt.type === 'click') {
+              const extent = this.getFeaturesExtent(feature.getProperties().features);
+              this.setExtent(extent);
+              return false;
+            } else {
+              return true;
+            }
           } else {
             // type no cluster
             properties = feature.getProperties();
           }
 
-          this.prepareAddPopup(properties, layer, feature, evt, layerpopup);
+          if ((typeof layerpopup === 'boolean' || Array.isArray(layerpopup)) ||
+            (layerpopup.event === 'click' && evt.type === 'click') ||
+            (!layerpopup.event && evt.type === 'click') ||
+            (layerpopup.event === 'move' && evt.type === 'pointermove')) {
+            this.prepareAddPopup(properties, layer, feature, evt, layerpopup);
+          }
         }
       }
     });
@@ -1326,7 +1336,10 @@ export class MapOlService {
       }
     }
 
-    if (typeof layerpopup === 'object' && !Array.isArray(layerpopup)) {
+    /** popup is boolean or array */
+    if (typeof layerpopup === 'boolean' || Array.isArray(layerpopup)) {
+      this.addPopup(args, popupProperties, null);
+    } else if (layerpopup) {
       /** async function where you can paste a html string to the callback */
       if ('asyncPupup' in layerpopup) {
         layerpopup.asyncPupup(popupProperties, (html) => {
@@ -1336,10 +1349,6 @@ export class MapOlService {
       } else {
         this.addPopup(args, popupProperties, null, layerpopup.event, layerpopup.single);
       }
-
-      /** popup is boolean */
-    } else {
-      this.addPopup(args, popupProperties, null);
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
If there is a cluster layer on the map with a configured popup by move event, the map automatically is zoomed in when hovering the cluster. This brings the user to a different view which he maybe don't like and not has expected.


## What is the new behavior?
Now zoom in on clusters with popups only work for the click events.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?

- [@dlr-eoc/map-ol](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/v7.2.0/projects/map-ol)
