### PR TITLE
Fix update of geojson layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Bug Fixes
 * **@dlr-eoc/map-ol:**
+  - Fix `updateGeojsonLayerParamsWith()` overwrites cluster source if the layer uses VectorLayer.cluster.
   - Do not automatically zoom in on Clusters if Popup event is move.
   - reuse popup on move [12f77a80](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/50/commits/12f77a80dc333471be3ea6431a21e6bcbeed487f) [#47](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/47)
   - getLayerByKey() not working on layergroups (recursive).

--- a/projects/demo-maps/src/assets/data/json/test-cities.json
+++ b/projects/demo-maps/src/assets/data/json/test-cities.json
@@ -1,0 +1,151 @@
+{
+  "type": "FeatureCollection",
+  "poperties": {
+    "description": "This are a few test cities and locations collected with geojson.io"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Munich"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.575899124145508,
+          48.137740422322295
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Landshut"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.152938842773436,
+          48.5370678355958
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Ulm"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.986572265624998,
+          48.40003249610685
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Ingolstadt"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.42578125,
+          48.75618876280552
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Paris"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          2.3291015625,
+          48.83579746243093
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Dreux"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.3677978515625,
+          48.73445537176822
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Meaux"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          2.8729248046875,
+          48.95497369808868
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Rome"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.480468749999998,
+          41.86956082699455
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Anzio"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.6287841796875,
+          41.4509614012039
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Berlin"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.403320312499998,
+          52.50953477032727
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Potsdam"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.058624267578125,
+          52.40074312027673
+        ]
+      }
+    }
+  ]
+}

--- a/projects/map-ol/ng-package.json
+++ b/projects/map-ol/ng-package.json
@@ -9,6 +9,7 @@
     "ol",
     "proj4",
     "@dlr-eoc/services-layers",
-    "@dlr-eoc/services-map-state"
+    "@dlr-eoc/services-map-state",
+    "@dlr-eoc/utils-maps"
   ]
 }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@dlr-eoc/services-map-state": "0.0.0-PLACEHOLDER",
     "@dlr-eoc/services-layers": "0.0.0-PLACEHOLDER",
+    "@dlr-eoc/utils-maps": "0.0.0-PLACEHOLDER",
     "ol": "0.0.0-PLACEHOLDER-VENDOR",
     "proj4": "0.0.0-PLACEHOLDER-VENDOR",
     "tslib": "0.0.0-PLACEHOLDER-VENDOR"

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -177,7 +177,7 @@ export interface IVectorLayerOptions extends ILayerOptions {
     style: any;
     [k: string]: any;
   };
-  /** true if show popup or set Array with keys of properties to show in popup  */
+  /** if true clusters points | or set a Object with cluster options e.g. distance ... depends on the map-library */
   cluster?: boolean | IAnyObject;
   type: TVectorLayertype;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors: no but this will come in the next PR


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As @voinSR recogniced, after PR #52 clustering with `VectorLayer.cluster` stopped working because the layer `source` is overridden in the function `updateGeojsonLayerParamsWith()`.


## What is the new behavior?
Now the function checks the type of the `source` and treats clusters separately.

Further a missing dependency was added to `@dlr-eoc/map-ol` and the description of the layer types was adjusted for the `cluster` property.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?

- @dlr-eoc/map-ol
- @dlr-eoc/services-layers
- demo-maps
