### PR TITLE
Angular popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,8 @@
 ### Features
 * **dlr-eoc/map-ol:**:
   - now allows for angular-components in popups. In any Ukis-Layer, just add a `dynamicPopup` field to the `popup` property.
-    ```typescript
-    popup: {
-        ...
-        dynamicPopup: {
-          component: SomeComponent,
-          getAttributes: (args: IPopupArgs) => {
-            return {... allInputsOfSomeComponent};
-          }
-        }
-      }
-    ```
-    If the popup-component requires any `@Input`'s, provide these with `getAttributes(args: IPopupArgs)`.
+    If the popup-component requires any `@Input`'s, provide these with `getAttributes(args: IPopupArgs)`. 
+    Addresses [Issue #14](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/14)
 * **@dlr-eoc/utils-maps:**:
   - created new custom renderer `InterpolationRenderer`.
     - Takes a vector-source (or a clustered vector-source) and does inverse-distance-interpolation on every pixel between the data points.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
   - `updateLayerParamsWith` now also works with GeojsonLayers: [issue 51](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/51)
 
 ### Features
+* **dlr-eoc/map-ol:**:
+  - now allows for angular-components in popups. In any Ukis-Layer, just add a `dynamicPopup` field to the `popup` property.
+    ```typescript
+    popup: {
+        ...
+        dynamicPopup: {
+          component: SomeComponent,
+          getAttributes: (args: IPopupArgs) => {
+            return {... allInputsOfSomeComponent};
+          }
+        }
+      }
+    ```
+    If the popup-component requires any `@Input`'s, provide these with `getAttributes(args: IPopupArgs)`.
 * **@dlr-eoc/utils-maps:**:
   - created new custom renderer `InterpolationRenderer`.
     - Takes a vector-source (or a clustered vector-source) and does inverse-distance-interpolation on every pixel between the data points.

--- a/projects/demo-maps/src/app/app.module.ts
+++ b/projects/demo-maps/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { ExampleLayerActionComponent } from './components/example-layer-action/e
 import { SunlightComponent } from './components/sunlight/sunlight.component';
 import { InterpolationSettingsComponent } from './components/interpolation-settings/interpolation-settings.component';
 import { RouteMap8Component } from './route-components/route-example-threejs/route-example-threejs.component';
+import { TablePopupComponent } from './components/table-popup/table-popup.component';
 
 @NgModule({
   declarations: [
@@ -57,7 +58,8 @@ import { RouteMap8Component } from './route-components/route-example-threejs/rou
     ExampleLayerActionComponent,
     SunlightComponent,
     RouteMap8Component,
-    InterpolationSettingsComponent
+    InterpolationSettingsComponent,
+    TablePopupComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
@@ -1,1 +1,2 @@
-<p>table-popup works!</p>
+<p>table-popup  with id {{ id }}</p>
+<div>{{ data | json }}</div>

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
@@ -1,5 +1,3 @@
-<p>table-popup  with id {{ id }}</p>
-
 <clr-datagrid>
     <clr-dg-column *ngFor="let kv of data | keyvalue">{{ kv.key }}</clr-dg-column>
     <clr-dg-row>

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
@@ -1,2 +1,8 @@
 <p>table-popup  with id {{ id }}</p>
-<div>{{ data | json }}</div>
+
+<clr-datagrid>
+    <clr-dg-column *ngFor="let kv of data | keyvalue">{{ kv.key }}</clr-dg-column>
+    <clr-dg-row>
+        <clr-dg-cell *ngFor="let kv of data | keyvalue">{{ kv.value }}</clr-dg-cell>
+    </clr-dg-row>
+</clr-datagrid>

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.html
@@ -1,0 +1,1 @@
+<p>table-popup works!</p>

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.spec.ts
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TablePopupComponent } from './table-popup.component';
+
+describe('TablePopupComponent', () => {
+  let component: TablePopupComponent;
+  let fixture: ComponentFixture<TablePopupComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TablePopupComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TablePopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-table-popup',
+  templateUrl: './table-popup.component.html',
+  styleUrls: ['./table-popup.component.scss']
+})
+export class TablePopupComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
@@ -1,29 +1,16 @@
-import { Component, OnInit, Input, AfterViewChecked, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-table-popup',
   templateUrl: './table-popup.component.html',
   styleUrls: ['./table-popup.component.scss']
 })
-export class TablePopupComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class TablePopupComponent implements OnInit {
 
   @Input() data: any;
-  public id: number;
 
   constructor() {
-    this.id = Math.random() * 1000000;
-    console.log(`table-popup constructed with id ${this.id}`);
   }
 
-  ngOnInit(): void {
-    // console.log(`table-popup on-init with id ${this.id}`);
-  }
-
-  ngAfterViewChecked(): void {
-    console.log(`checking table-popup with id ${this.id}`);
-  }
-
-  ngOnDestroy(): void {
-    console.log(`destroying table-popup with id ${this.id}`);
-  }
+  ngOnInit(): void {}
 }

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
@@ -1,15 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input, AfterViewChecked } from '@angular/core';
 
 @Component({
   selector: 'app-table-popup',
   templateUrl: './table-popup.component.html',
   styleUrls: ['./table-popup.component.scss']
 })
-export class TablePopupComponent implements OnInit {
+export class TablePopupComponent implements OnInit, AfterViewChecked {
 
-  constructor() { }
+  @Input() data: any;
+  public id = Math.random() * 1000000;
+
+  constructor() {
+    console.log(`table-popup constructed with id ${this.id}`);
+  }
+
+  ngAfterViewChecked(): void {
+    console.log(`checking table-popup with id ${this.id}`);
+  }
 
   ngOnInit(): void {
+    console.log(`table-popup on-init with id ${this.id}`);
   }
 
 }

--- a/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
+++ b/projects/demo-maps/src/app/components/table-popup/table-popup.component.ts
@@ -1,25 +1,29 @@
-import { Component, OnInit, Input, AfterViewChecked } from '@angular/core';
+import { Component, OnInit, Input, AfterViewChecked, OnDestroy } from '@angular/core';
 
 @Component({
   selector: 'app-table-popup',
   templateUrl: './table-popup.component.html',
   styleUrls: ['./table-popup.component.scss']
 })
-export class TablePopupComponent implements OnInit, AfterViewChecked {
+export class TablePopupComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   @Input() data: any;
-  public id = Math.random() * 1000000;
+  public id: number;
 
   constructor() {
+    this.id = Math.random() * 1000000;
     console.log(`table-popup constructed with id ${this.id}`);
+  }
+
+  ngOnInit(): void {
+    // console.log(`table-popup on-init with id ${this.id}`);
   }
 
   ngAfterViewChecked(): void {
     console.log(`checking table-popup with id ${this.id}`);
   }
 
-  ngOnInit(): void {
-    console.log(`table-popup on-init with id ${this.id}`);
+  ngOnDestroy(): void {
+    console.log(`destroying table-popup with id ${this.id}`);
   }
-
 }

--- a/projects/demo-maps/src/app/route-components/route-example-custom-layers/route-map4.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-custom-layers/route-map4.component.ts
@@ -280,8 +280,8 @@ export class RouteMap4Component implements OnInit, AfterViewInit {
       visible: true,
       popup: {
         event: 'move',
-        filterkeys: ['name', 'region_un', 'region_wb'],
-        properties: { name: 'Name' },
+        filterkeys: ['name', 'region_un', 'region_wb'],  // of all the feature's properties, only pass these to the popup-render-function
+        properties: { name: 'Name' },  // rename the feature.property key "name" to "Name"
         options: { autoPan: false }
       },
       custom_layer: new olVectorTileLayer({

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -5,6 +5,7 @@ import { OsmTileLayer, EocLitemapTile, OpenSeaMap, EocBasemapTile, EocBaseoverla
 import { MapOlService, IMapControls } from '@dlr-eoc/map-ol';
 import { ZommNumberControl } from './ol-custom-control';
 import { getFeatureInfoPopup } from './map-helpers';
+import { TablePopupComponent } from '../../components/table-popup/table-popup.component';
 
 @Component({
   selector: 'app-route-map',
@@ -233,7 +234,13 @@ export class RouteMapComponent implements OnInit {
         ]
       },
       visible: false,
-      popup: { event: 'move' }
+      popup: {
+        event: 'move',
+        dynamicPopup: {
+          component: TablePopupComponent,
+          attributes: {}
+        }
+      }
     });
 
     const vectorLayer3 = new VectorLayer({

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -238,7 +238,9 @@ export class RouteMapComponent implements OnInit {
         event: 'move',
         dynamicPopup: {
           component: TablePopupComponent,
-          attributes: {}
+          attributes: {
+            data: [1, 2, 3]
+          }
         }
       }
     });

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, HostBinding } from '@angular/core';
 import { LayersService, RasterLayer, VectorLayer, LayerGroup, Layer, WmtsLayer, WmsLayer } from '@dlr-eoc/services-layers';
 import { MapStateService } from '@dlr-eoc/services-map-state';
 import { OsmTileLayer, EocLitemapTile, OpenSeaMap, EocBasemapTile, EocBaseoverlayTile, EocLiteoverlayTile, BlueMarbleTile, WorldReliefBwTile, HillshadeTile } from '@dlr-eoc/base-layers-raster';
-import { MapOlService, IMapControls } from '@dlr-eoc/map-ol';
+import { MapOlService, IMapControls, IPopupArgs } from '@dlr-eoc/map-ol';
 import { ZommNumberControl } from './ol-custom-control';
 import { getFeatureInfoPopup } from './map-helpers';
 import { TablePopupComponent } from '../../components/table-popup/table-popup.component';
@@ -238,8 +238,8 @@ export class RouteMapComponent implements OnInit {
         event: 'move',
         dynamicPopup: {
           component: TablePopupComponent,
-          attributes: {
-            data: {'a': 1, 'b': 2, 'c': 3}
+          getAttributes: (args: IPopupArgs) => {
+            return {data: args.properties};
           }
         }
       }

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -239,7 +239,7 @@ export class RouteMapComponent implements OnInit {
         dynamicPopup: {
           component: TablePopupComponent,
           attributes: {
-            data: [1, 2, 3]
+            data: {'a': 1, 'b': 2, 'c': 3}
           }
         }
       }

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, HostBinding } from '@angular/core';
 import { LayersService, RasterLayer, VectorLayer, LayerGroup, Layer, WmtsLayer } from '@dlr-eoc/services-layers';
 import { MapStateService } from '@dlr-eoc/services-map-state';
 import { OsmTileLayer, EocLitemapTile, OpenSeaMap, EocBasemapTile, EocBaseoverlayTile, EocLiteoverlayTile, BlueMarbleTile, WorldReliefBwTile, HillshadeTile } from '@dlr-eoc/base-layers-raster';
-import { MapOlService, IMapControls, IPopupArgs } from '@dlr-eoc/map-ol';
+import { MapOlService, IMapControls, IDynamicPopupArgs } from '@dlr-eoc/map-ol';
 import { ZommNumberControl } from './ol-custom-control';
 import { getFeatureInfoPopup } from './map-helpers';
 import { TablePopupComponent } from '../../components/table-popup/table-popup.component';
@@ -243,7 +243,7 @@ export class RouteMapComponent implements OnInit {
         event: 'move',
         dynamicPopup: {
           component: TablePopupComponent,
-          getAttributes: (args: IPopupArgs) => {
+          getAttributes: (args: IDynamicPopupArgs) => {
             return {data: args.properties};
           }
         }

--- a/projects/map-ol/ng-package.json
+++ b/projects/map-ol/ng-package.json
@@ -9,6 +9,7 @@
     "ol",
     "proj4",
     "@dlr-eoc/services-layers",
-    "@dlr-eoc/services-map-state"
+    "@dlr-eoc/services-map-state",
+    "@dlr-eoc/utils-maps"
   ]
 }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@dlr-eoc/services-map-state": "0.0.0-PLACEHOLDER",
     "@dlr-eoc/services-layers": "0.0.0-PLACEHOLDER",
+    "@dlr-eoc/utils-maps": "0.0.0-PLACEHOLDER",
     "ol": "0.0.0-PLACEHOLDER-VENDOR",
     "proj4": "0.0.0-PLACEHOLDER-VENDOR",
     "tslib": "0.0.0-PLACEHOLDER-VENDOR"

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -97,6 +97,7 @@ export class MapOlService {
   private hitTolerance = 0;
   /** 'olProjection' */
   public projectionChange = new Subject<olProjection>();
+  private dynamicPopupComponents: {[key: string]: ComponentRef<any>} = {};
   constructor(
     private crf: ComponentFactoryResolver,
     private app: ApplicationRef,
@@ -1443,6 +1444,12 @@ export class MapOlService {
       const hasPopup = this.getPopups().find(item => (item.getId() === overlay.getId() && overlay.getId() !== moveID));
       if (hasPopup) {
         this.map.removeOverlay(hasPopup);
+        const id = hasPopup.getId().toString();
+        if (this.dynamicPopupComponents[id]) {
+          const compRef = this.dynamicPopupComponents[id];
+          compRef.destroy();
+          delete this.dynamicPopupComponents[id];
+        }
       }
       this.map.addOverlay(overlay);
     }
@@ -1470,6 +1477,8 @@ export class MapOlService {
         }
       }
       this.app.attachView(popupBody.hostView);
+      const id = overlay.getId().toString();
+      this.dynamicPopupComponents[id] = popupBody;
     }
 
     const container = document.createElement('div');
@@ -1485,6 +1494,12 @@ export class MapOlService {
       const closeFunction = () => {
         closer.removeEventListener('click', closeFunction, false);
         this.map.removeOverlay(overlay);
+        const id = overlay.getId().toString();
+        if (this.dynamicPopupComponents[id]) {
+          const compRef = this.dynamicPopupComponents[id];
+          compRef.destroy();
+          delete this.dynamicPopupComponents[id];
+        }
       };
       closer.addEventListener('click', closeFunction, false);
     }
@@ -1501,6 +1516,12 @@ export class MapOlService {
     popups.forEach((overlay) => {
       if (overlay.get(OVERLAY_TYPE_KEY) === 'popup') {
         this.map.removeOverlay(overlay);
+        const id = overlay.getId().toString();
+        if (this.dynamicPopupComponents[id]) {
+          const compRef = this.dynamicPopupComponents[id];
+          compRef.destroy();
+          delete this.dynamicPopupComponents[id];
+        }
       }
     });
   }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -79,7 +79,7 @@ const WGS84 = 'EPSG:4326';
  */
 export interface IPopupArgs {
   modelName: string;
-  properties: any;
+  properties: popup['properties'];
   layer: olLayer<any>;
   feature?: olFeature<any> | olRenderFeature;
   event: olMapBrowserEvent<PointerEvent>;
@@ -92,8 +92,11 @@ export interface IPopupArgs {
  * Most notably, we want @dlr-eoc/services-layers.popup.filterkeys and
  * @dlr-eoc/services-layers.popup.properties to be available, too.
  */
-export interface IDynamicPopupArgs extends IPopupArgs {
-  properties: popup;
+export interface IDynamicPopupArgs {
+  properties: popup['properties'];
+  layer: IPopupArgs['layer'];
+  feature?: IPopupArgs['feature'];
+  event: olMapBrowserEvent<PointerEvent>;
   dynamicPopup: popup['dynamicPopup'];
 }
 
@@ -1488,7 +1491,6 @@ export class MapOlService {
       this.destroyDynamicPopupComponent(id);
       // Only now create a new one.
       const dArgs: IDynamicPopupArgs = {
-        modelName: args.modelName,
         event: args.event,
         layer: args.layer,
         feature: args.feature || null,

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -80,10 +80,7 @@ export interface IPopupArgs {
   feature?: olFeature<any> | olRenderFeature;
   event: olMapBrowserEvent<PointerEvent>;
   popupFn?: popup['pupupFunktion'];
-  dynamicPopup?: {
-    component: Type<any>;
-    getAttributes?: (args: IPopupArgs) => object;
-  };
+  dynamicPopup?: popup['dynamicPopup'];
 }
 
 @Injectable({
@@ -101,8 +98,8 @@ export class MapOlService {
    * This object keeps track of currently bound angular-components that are being used as popups.
    * We keep a reference to them here so that we can remove them again after they are no longer displayed.
    */
-  private dynamicPopupComponents: {[key: string]: ComponentRef<any>} = {};
-  
+  private dynamicPopupComponents: Map<string, ComponentRef<any>> = new Map();
+
   constructor(
     private crf: ComponentFactoryResolver,
     private app: ApplicationRef,
@@ -1548,9 +1545,9 @@ export class MapOlService {
    * @param id : The string under which the popup-component has been stored in `this.dynamicPopupComponents`
    */
   private destroyDynamicPopupComponent(id: string): void {
-    if (this.dynamicPopupComponents[id]) {
-      this.dynamicPopupComponents[id].destroy();
-      delete this.dynamicPopupComponents[id];
+    if (this.dynamicPopupComponents.has(id)) {
+      this.dynamicPopupComponents.get(id).destroy();
+      this.dynamicPopupComponents.delete(id);
     }
   }
 

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Type } from '@angular/core';
 
 
 import { Layer, VectorLayer, CustomLayer, RasterLayer, popup, WmtsLayer, WmsLayer, TGeoExtent } from '@dlr-eoc/services-layers';
@@ -80,6 +80,10 @@ export interface IPopupArgs {
   feature?: olFeature<any> | olRenderFeature;
   event: olMapBrowserEvent<PointerEvent>;
   popupFn?: popup['pupupFunktion'];
+  dynamicPopup?: {
+    component: Type<any>;
+    attributes: object;
+  };
 }
 
 @Injectable({
@@ -1333,6 +1337,8 @@ export class MapOlService {
         /** function to create html string */
       } else if (layerpopup.pupupFunktion) {
         args.popupFn = layerpopup.pupupFunktion;
+      } else if (layerpopup.dynamicPopup) {
+        args.dynamicPopup = layerpopup.dynamicPopup;
       }
     }
 
@@ -1444,8 +1450,9 @@ export class MapOlService {
     let popupHtml = '';
     if (args.popupFn) {
       popupHtml = args.popupFn(popupObj);
-    }
-    else if (html && (!popupObj || Object.keys(popupObj).length === 0)) {
+    } else if (args.dynamicPopup) {
+      // @TODO: insert angular component into `content` element.
+    } else if (html && (!popupObj || Object.keys(popupObj).length === 0)) {
       popupHtml = html;
     } else {
       popupHtml = this.createPopupHtml(popupObj);

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Type, ComponentFactoryResolver, ApplicationRef, Injector } from '@angular/core';
+import { Injectable, Type, ComponentFactoryResolver, ApplicationRef, Injector, ComponentRef } from '@angular/core';
 
 
 import { Layer, VectorLayer, CustomLayer, RasterLayer, popup, WmtsLayer, WmsLayer, TGeoExtent } from '@dlr-eoc/services-layers';
@@ -82,7 +82,7 @@ export interface IPopupArgs {
   popupFn?: popup['pupupFunktion'];
   dynamicPopup?: {
     component: Type<any>;
-    attributes: object;
+    getAttributes: (args: IPopupArgs) => object;
   };
 }
 
@@ -1463,9 +1463,10 @@ export class MapOlService {
     if (args.dynamicPopup) {
       const factory = this.crf.resolveComponentFactory(args.dynamicPopup.component);
       const popupBody = factory.create(this.injector, [], content);
-      for (const key in args.dynamicPopup.attributes) {
-        if (args.dynamicPopup.attributes[key] !== 'undefined') {
-          popupBody.instance[key] = args.dynamicPopup.attributes[key];
+      const attributes = args.dynamicPopup.getAttributes(args);
+      for (const key in attributes) {
+        if (attributes[key] !== 'undefined') {
+          popupBody.instance[key] = attributes[key];
         }
       }
       this.app.attachView(popupBody.hostView);

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1379,8 +1379,8 @@ export class MapOlService {
       } else {
         coordinate = args.event.coordinate;
       }
-      const container = this.createPopupContainer(movePopup, args, popupObj, html, event);
-      movePopup.setElement(container);
+      // const container = this.createPopupContainer(movePopup, args, popupObj, html, event);
+      // movePopup.setElement(container);
       movePopup.setPosition(coordinate);
     } else if (args.event.type === 'pointermove' && !event) {
       /** remove move popup if move on a click layer */

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -62,7 +62,7 @@ import olEvent from 'ol/events/Event';
 import { Options as DragBoxOptions } from 'ol/interaction/DragBox';
 import { getUid as olGetUid } from 'ol/util';
 import { Subject } from 'rxjs';
-import { flattenLayers } from '@dlr-eoc/utils-maps/src/public-api';
+import { flattenLayers } from '@dlr-eoc/utils-maps';
 
 
 export declare type Tgroupfiltertype = 'baselayers' | 'layers' | 'overlays' | 'Baselayers' | 'Overlays' | 'Layers';

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1379,8 +1379,8 @@ export class MapOlService {
       } else {
         coordinate = args.event.coordinate;
       }
-      // const container = this.createPopupContainer(movePopup, args, popupObj, html, event);
-      // movePopup.setElement(container);
+      const container = this.createPopupContainer(movePopup, args, popupObj, html, event);
+      movePopup.setElement(container);
       movePopup.setPosition(coordinate);
     } else if (args.event.type === 'pointermove' && !event) {
       /** remove move popup if move on a click layer */
@@ -1468,6 +1468,14 @@ export class MapOlService {
     }
     content.innerHTML = popupHtml;
     if (args.dynamicPopup) {
+      // To prevent memory leak:
+      // if a popup already has been created (for example `popup_move_ID`),
+      // then destroy it before creating a new one.
+      const id = overlay.getId().toString();
+      if (this.dynamicPopupComponents[id]) {
+        this.dynamicPopupComponents[id].destroy();
+        delete this.dynamicPopupComponents[id];
+      }
       const factory = this.crf.resolveComponentFactory(args.dynamicPopup.component);
       const popupBody = factory.create(this.injector, [], content);
       const attributes = args.dynamicPopup.getAttributes(args);
@@ -1477,7 +1485,6 @@ export class MapOlService {
         }
       }
       this.app.attachView(popupBody.hostView);
-      const id = overlay.getId().toString();
       this.dynamicPopupComponents[id] = popupBody;
     }
 

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -97,7 +97,12 @@ export class MapOlService {
   private hitTolerance = 0;
   /** 'olProjection' */
   public projectionChange = new Subject<olProjection>();
+  /**
+   * This object keeps track of currently bound angular-components that are being used as popups.
+   * We keep a reference to them here so that we can remove them again after they are no longer displayed.
+   */
   private dynamicPopupComponents: {[key: string]: ComponentRef<any>} = {};
+  
   constructor(
     private crf: ComponentFactoryResolver,
     private app: ApplicationRef,

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -79,7 +79,7 @@ const WGS84 = 'EPSG:4326';
  */
 export interface IPopupArgs {
   modelName: string;
-  properties: popup['properties']; // have been filtered beforehand by popup['filterkeys'] (if given)
+  properties: popup['properties']; // will be filtered by popup['filterkeys'] (if given)
   layer: olLayer<any>;
   feature?: olFeature<any> | olRenderFeature;
   event: olMapBrowserEvent<PointerEvent>;
@@ -89,7 +89,7 @@ export interface IPopupArgs {
 
 
 export interface IDynamicPopupArgs {
-  properties: popup['properties']; // have been filtered beforehand by popup['filterkeys'] (if given)
+  properties: popup['properties']; // will be filtered by popup['filterkeys'] (if given)
   layer: IPopupArgs['layer'];
   feature?: IPopupArgs['feature'];
   event: olMapBrowserEvent<PointerEvent>;

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -79,7 +79,7 @@ const WGS84 = 'EPSG:4326';
  */
 export interface IPopupArgs {
   modelName: string;
-  properties: popup['properties'];
+  properties: popup['properties']; // have been filtered beforehand by popup['filterkeys'] (if given)
   layer: olLayer<any>;
   feature?: olFeature<any> | olRenderFeature;
   event: olMapBrowserEvent<PointerEvent>;
@@ -87,13 +87,9 @@ export interface IPopupArgs {
   dynamicPopup?: popup['dynamicPopup'];
 }
 
-/**
- * In dynamic popups we want even more context-information than in static popups.
- * Most notably, we want @dlr-eoc/services-layers.popup.filterkeys and
- * @dlr-eoc/services-layers.popup.properties to be available, too.
- */
+
 export interface IDynamicPopupArgs {
-  properties: popup['properties'];
+  properties: popup['properties']; // have been filtered beforehand by popup['filterkeys'] (if given)
   layer: IPopupArgs['layer'];
   feature?: IPopupArgs['feature'];
   event: olMapBrowserEvent<PointerEvent>;

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -29,9 +29,9 @@ export interface ILayerStyleSet extends IAnyObject {
 }
 
 export interface popup {
-  /** limit properties */
+  /** limit layer or feature properties: only those properties of a layer/feature, that are listed in this array, are being passed through to a popup-render-function */
   filterkeys?: Array<string>;
-  /** To overwrite the keys of the layer properties */
+  /** To overwrite the keys (and only the keys) of the layer/feature properties. Object has the form {"oldKey": "newKey"} */
   properties?: IAnyObject;
   /** function to create html string - popupobj: nativeLayer */
   pupupFunktion?: (popupobj: IAnyObject) => string;

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -40,7 +40,7 @@ export interface popup {
   /** create popup using angular component */
   dynamicPopup?: {
     component: Type<any>;
-    attributes: object;
+    getAttributes: (args: any) => object;
   };
   /** default event is click - use move for a popup on hover */
   event?: 'move' | 'click';

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -37,6 +37,11 @@ export interface popup {
   pupupFunktion?: (popupobj: IAnyObject) => string;
   /** async function where you can paste a html string to the callback - popupobj: nativeLayer */
   asyncPupup?: (popupobj: any, cb: (html: any) => void) => void;
+  /** create popup using angular component */
+  dynamicPopup?: {
+    component: Type<any>;
+    attributes: object;
+  };
   /** default event is click - use move for a popup on hover */
   event?: 'move' | 'click';
   /** default is false - removes the other popups if the next is added */

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -40,7 +40,7 @@ export interface popup {
   /** create popup using angular component */
   dynamicPopup?: {
     component: Type<any>;
-    getAttributes: (args: any) => object;
+    getAttributes?: (args: any) => object;
   };
   /** default event is click - use move for a popup on hover */
   event?: 'move' | 'click';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [14](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/14)

At the moment, UKIS popups are static. This is problematic when we want interactivity in our popups.
Cases where we might want interactive popups:
 - popups that need to be translated to other languages on the fly
 - graphics that should react to user-interactions (like mouse-hover, clicking etc.)
 - popups that need to react to changes in global application state by listening to a service
 - ...


## What is the new behavior?

UKIS now allows for angular-components in popups. In any Ukis-Layer, just add a `dynamicPopup` field to the `popup` property.
```typescript
    popup: {
        ...
        dynamicPopup: {
          component: SomeComponent,
          getAttributes: (args: IPopupArgs) => {
            return {... allInputsOfSomeComponent};
          }
        }
      }
```
If the popup-component requires any `@Input`'s, provide these with `getAttributes(args: IPopupArgs)`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
 - `@dlr-eoc/map-ol`
 - `demo-maps`

To keep track of the angular-components, we keep a reference to them in `MapOlService.dynamicPopupComponents: {[key: string]: ComponentRef<any>}`. We need this reference so that the components can be removed from angular after the popup is no longer displayed.
It feels a little unclean, however, to add this state to `MapOlService`. In another issue/PR it might make sense to try and declutter the service a little bit.