### PR TITLE
refactor: exposing WmsService from

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.4.0-next.0",
+  "version": "7.3.0-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.0",
+  "version": "7.3.0-next.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.1",
+  "version": "7.3.0-next.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.0",
+  "version": "7.4.0-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.1",
+  "version": "7.3.0-next.2",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.0",
+  "version": "7.3.0-next.1",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.4.0-next.0",
+  "version": "7.3.0-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "7.3.0-next.0",
+  "version": "7.4.0-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "bugs": {

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1591,7 +1591,7 @@ export class MapOlService {
       }
     }
     this.app.attachView(popupBody.hostView);
-    this.dynamicPopupComponents[id] = popupBody;
+    this.dynamicPopupComponents.set(id, popupBody);
   }
 
   /**

--- a/projects/services-ogc/README.md
+++ b/projects/services-ogc/README.md
@@ -151,6 +151,10 @@ Example:
 
 This library was generated with [Angular CLI](https://github.com/angular/angular-cli) version 8.2.14.
 
+
+## WMS
+While openlayers already has a decent WMS-client, it doesn't quite cover some operations fully. The service `WMSService` allows to make calls to a WMS's `GetCapabilities`, so that existing layers can be parsed automatically.
+
 ## Code scaffolding
 
 Run `ng generate component component-name --project services-ogc` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project services-ogc`.

--- a/projects/services-ogc/src/lib/wps/wpsclient.ts
+++ b/projects/services-ogc/src/lib/wps/wpsclient.ts
@@ -3,6 +3,19 @@ import { Injectable, Inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 
+/**
+ * This file exports a wrapper around @dlr-eoc/utils-ogc/Wps for backwards compatibility.
+ * While the WPS functionality has been moved to utils-ogc, we still maintain this wrapper
+ * so that older clients don't need to change their imports.
+ */
+
+
+export { Cache, FakeCache } from '@dlr-eoc/utils-ogc';
+export { WpsDataDescription, WpsInputDescription, WpsOutputDescription, WpsData, WpsInput, WpsResult,
+    WpsBboxDescription, WpsBboxValue, WpsBboxData, WpsVersion, WpsDataFormat,
+    WpsState, WpsCapability, WpsProcessDescription, WpsServerDescription, WpsMarshaller } from '@dlr-eoc/utils-ogc';
+
+
 @Injectable()
 export class WpsClient extends WCBasic {
     constructor(

--- a/projects/services-ogc/src/public-api.ts
+++ b/projects/services-ogc/src/public-api.ts
@@ -8,3 +8,4 @@ export * from './lib/owc/types/owc-json';
 export * from './lib/owc/types/eoc-owc-json';
 export * from './lib/wps/wpsclient';
 export * from './lib/wmts/wmtsclient.service';
+export * from './lib/wms/wms.service';


### PR DESCRIPTION
@dlr-eoc/services-ogc

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [66](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/66)

`@dlr-eoc/serivces-ogc` does not expose the service `WmsService`.

## What is the new behavior?

With the service now exposed, we can more comfortably parse a WMS'es `GetCapabilities` document.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
 - `@dlr-eoc/services-ogc` only
