### PR TITLE
fix: custom-layers containing olLayerGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Bug Fixes
+* **@dlr-eoc/map-ol:**
+  - Fixed an issue with z-index of UkisCustomLayers containing an OlLayerGroup. Before the fix the layergroup's layers would always appear at the very bottom of the map, even below base-layers.
+
+
 # [7.3.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v7.3.0) (2021-04-20) (Layer, Utils Features and bug fixes maps)
 ### Bug Fixes
 * **@dlr-eoc/layer-control:**

--- a/projects/map-ol/src/lib/map-ol.component.spec.ts
+++ b/projects/map-ol/src/lib/map-ol.component.spec.ts
@@ -3,15 +3,20 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MapOlComponent } from './map-ol.component';
 import { LayersService, VectorLayer } from '@dlr-eoc/services-layers';
 import { RasterLayer } from '@dlr-eoc/services-layers';
-import { LayerGroup } from '@dlr-eoc/services-layers';
+import { LayerGroup, CustomLayer } from '@dlr-eoc/services-layers';
+import { OsmTileLayer } from '@dlr-eoc/base-layers-raster';
 import { of } from 'rxjs';
 import { MapStateService } from '@dlr-eoc/services-map-state';
 import { Injectable } from '@angular/core';
 import testFeatureData from '../assets/testFeatureCollection.json';
 import olVectorLayer from 'ol/layer/Vector';
+import olLayerGroup from 'ol/layer/Group';
+import olVectorSource from 'ol/source/Vector';
+import olGeoJSON from 'ol/format/GeoJSON';
+import { MapOlService } from './map-ol.service';
 
 /**
- * this service extends the LayersService to mimik its behaviour. The getLayerGroups function is overwritten to
+ * this service extends the LayersService to mimic its behavior. The getLayerGroups function is overwritten to
  * get test data for following tests.
  */
 @Injectable()
@@ -46,6 +51,7 @@ describe('MapOlComponent', () => {
     TestBed.configureTestingModule({
       declarations: [MapOlComponent],
       providers: [
+        MapOlService,
         { provide: LayersService, useClass: MockLayersService },
         { provide: MapStateService, useClass: MapStateService }
       ]
@@ -104,5 +110,132 @@ describe('MapOlComponent', () => {
     component.layersSvc.updateLayer(vectorLayer);
     // now, after calling `updateLayer`, the data is present on the ol-layer
     expect((component.map.getLayers().getArray()[1].getLayersArray()[0] as olVectorLayer).getSource().getFeatures().length).toEqual(4);
+  });
+
+  it('should use the correct z-index for Ukis-custom-layers even if they contain an olLayerGroup', () => {
+    const service: MapOlService = TestBed.inject(MapOlService);
+    service.createMap();
+
+
+    const osmLayer = new OsmTileLayer();
+    component.layersSvc.addLayer(osmLayer, 'Baselayers');
+    const baseLayer = new VectorLayer({
+      id: 'vectorLayer',
+      name: 'vectorLayer',
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: [{
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'Point',
+              coordinates: [11.71142578125, 46.5739667965278]
+            }
+          }]
+      }
+    });
+    component.layersSvc.addLayer(baseLayer, 'Layers');
+
+    const layer1 = new olVectorLayer({
+      source: new olVectorSource({
+        features: new olGeoJSON({
+          dataProjection: 'EPSG:4326',
+          featureProjection: service.EPSG
+        }).readFeatures({
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  10.37109375,
+                  50.064191736659104
+                ]
+              }
+            },
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  11.997070312499998,
+                  50.064191736659104
+                ]
+              }
+            }
+          ]
+        })
+      })
+    });
+    const layer2 = new olVectorLayer({
+      source: new olVectorSource({
+        features: new olGeoJSON({
+          dataProjection: 'EPSG:4326',
+          featureProjection: service.EPSG
+        }).readFeatures({
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                  [
+                    8.67919921875,
+                    49.167338606291075
+                  ],
+                  [
+                    10.458984375,
+                    48.4146186174932
+                  ],
+                  [
+                    11.997070312499998,
+                    48.4146186174932
+                  ],
+                  [
+                    13.24951171875,
+                    48.821332549646634
+                  ],
+                  [
+                    13.7109375,
+                    49.396675075193976
+                  ]
+                ]
+              }
+            }
+          ]
+        })
+      })
+    });
+
+    const layerGroup = new olLayerGroup({
+      layers: [layer1, layer2]
+    });
+
+    const ukisLayer = new CustomLayer({
+      custom_layer: layerGroup,
+      id: 'olGroupLayer',
+      name: 'Ol-Group Layer',
+      filtertype: 'Layers',
+      visible: true
+    });
+
+    component.layersSvc.addLayer(ukisLayer, 'Layers');
+
+    const lowLayer = service.getLayerByKey({key: 'id', value: baseLayer.id});
+    const higherLayer = service.getLayerByKey({key: 'id', value: 'olGroupLayer'});
+    const higherLayersChild = higherLayer.getLayersArray()[0];
+
+    expect(lowLayer.getZIndex()).toBeDefined();
+    expect(higherLayer.getZIndex()).toBeDefined();
+    expect(higherLayersChild.getZIndex()).toBeDefined();
+    expect(lowLayer.getZIndex() <= higherLayer.getZIndex()).toBeTrue();
+    expect(lowLayer.getZIndex() <= higherLayersChild.getZIndex()).toBeTrue();
+    expect(higherLayer.getZIndex() <= higherLayersChild.getZIndex()).toBeTrue();
   });
 });

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -172,7 +172,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
               ollayer.setZIndex(layers.indexOf(layer) + otherlayerslength);
               // addresses an issue in openlayers: https://github.com/openlayers/openlayers/issues/6654
               if (ollayer instanceof olLayerGroup) {
-                (ollayer as olLayerGroup).getLayersArray().map(l => {
+                (ollayer as olLayerGroup).getLayers().forEach(l => {
                   l.setZIndex(layers.indexOf(layer) + otherlayerslength);
                 });
               }

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -170,6 +170,12 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
           if (ollayer) {
             if (ollayer.getZIndex() !== layers.indexOf(layer) + otherlayerslength) {
               ollayer.setZIndex(layers.indexOf(layer) + otherlayerslength);
+              // addresses an issue in openlayers: https://github.com/openlayers/openlayers/issues/6654
+              if (ollayer instanceof olLayerGroup) {
+                (ollayer as olLayerGroup).getLayersArray().map(l => {
+                  l.setZIndex(layers.indexOf(layer) + otherlayerslength);
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
get assigned a sensible z-index

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/master/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Assume we want to add a UkisCustomLayer, let's call it `collectionLayer`, to the 'Layers' group. As its `custom_layer`, that new UkisCustomLayer has an `olLayerGroup`.

When would we want to do this?
 - Common when dealing with time-sliders. Imagine `collectionLayer` contains a group of olLayers that we want to move through using a timeslider.

Before the fix the `collectionLayer` would always appear at the very bottom of the map, even below the base-layers.
There is actually a known issue in openlayers related to this: https://github.com/openlayers/openlayers/issues/6654 

## What is the new behavior?
olLayerGroup's child-layers now have the same z-index as their parent.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
 - @dlr-eoc/map-ol
