### PR TITLE
fix: use background from style when creating vector tile layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 * **@dlr-eoc/map-ol:**
+  - Use `applyBackground()` from 'ol-mapbox-style' when creating vector tile layers.
   - Remove LayerGroups from map before add `baselayerGroup`, `layersGroup` and `overlayGroup`.
   - Set bbox for olLayerGroup layers in `create_custom_layer`.
   - Show popups on transparent features [Issue #120](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/120).

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -36,7 +36,7 @@ import olVectorTile from 'ol/source/VectorTile';
 import olVectorTileLayer from 'ol/layer/VectorTile';
 import { Options as olVectorTileLayerOptions } from 'ol/layer/VectorTile';
 import olVectorTileSource from 'ol/source/VectorTile';
-import { applyStyle } from 'ol-mapbox-style';
+import { applyBackground, applyStyle } from 'ol-mapbox-style';
 import { createXYZ } from 'ol/tilegrid';
 import olMVT from 'ol/format/MVT';
 
@@ -945,6 +945,7 @@ export class MapOlService {
       const style = l?.options?.style;
       const mapboxSourceKey = l?.options?.styleSource;
       if (style && mapboxSourceKey) {
+        applyBackground(newlayer, style);
         /**
          * The urls from olsource are not used if sources.<source>.url are set in the open map style
          * if tms service is used or no correct TileJSON is available we have to override the urls


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On creation of vector tile layers with [ol-mapbox-style](https://github.com/openlayers/ol-mapbox-style), [applyBackground()](https://github.com/openlayers/ol-mapbox-style#applybackground) was not called to set the background color of the style.


## What is the new behavior?
The background color is now applied to the new layer `applyBackground(newlayer, style)`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
- `@dlr-eoc/map-ol`
