### PR TITLE
fix: display of vector dataSources in map-cesium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2386,11 +2386,11 @@
       }
     },
     "node_modules/@cesium/engine": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-2.4.1.tgz",
-      "integrity": "sha512-8f0hBzhPUSimYLZ+cmQ0rSudm+8zYD3sBMvJcPSVt0wDpLT7tvBt9swC2v5qC2gOwGOeyFnJhXKes3ICE6SaDA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-3.0.2.tgz",
+      "integrity": "sha512-p7xawdNn6dHOSMD/LtedSrsLqxcTyISi3JpKoKQd8DV4Yev0uwCbo8p7V7NqGXQjPqW7Tq0yAvBYvOMBpg9d1g==",
       "dependencies": {
-        "@tweenjs/tween.js": "^18.6.4",
+        "@tweenjs/tween.js": "^21.0.0",
         "@zip.js/zip.js": "2.4.x",
         "autolinker": "^4.0.0",
         "bitmap-sdf": "^1.0.3",
@@ -2399,7 +2399,7 @@
         "grapheme-splitter": "^1.0.4",
         "jsep": "^1.3.8",
         "kdbush": "^4.0.1",
-        "ktx-parse": "^0.5.0",
+        "ktx-parse": "^0.6.0",
         "lerc": "^2.0.0",
         "mersenne-twister": "^1.1.0",
         "meshoptimizer": "^0.19.0",
@@ -2419,11 +2419,11 @@
       "integrity": "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg=="
     },
     "node_modules/@cesium/widgets": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-2.3.1.tgz",
-      "integrity": "sha512-KC/GtcrS2t9Vf710C5a0ArG9ZawVeUhA37ISzFSCqVoAmlNd2YAjv00SZZOMtFqjMFWr7sOcm3BwMjWXnTWjvw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-3.0.2.tgz",
+      "integrity": "sha512-ai3BbbxQYcj639jG2rPI+4zz6Tmz+xFG+ynUYjIrYa672iqe2VXQy1ahX4wvmwEvf0YLROJuT53jU7Nq0KZHmA==",
       "dependencies": {
-        "@cesium/engine": "2.4.1",
+        "@cesium/engine": "^3.0.2",
         "nosleep.js": "^0.12.0"
       },
       "engines": {
@@ -4108,9 +4108,9 @@
       }
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ=="
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-21.0.0.tgz",
+      "integrity": "sha512-qVfOiFh0U8ZSkLgA6tf7kj2MciqRbSCWaJZRwftVO7UbtVDNsZAXpWXqvCDtIefvjC83UJB+vHTDOGm5ibXjEA=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -12157,9 +12157,9 @@
       }
     },
     "node_modules/ktx-parse": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.5.0.tgz",
-      "integrity": "sha512-5IZrv5s1byUeDTIee1jjJQBiD5LPDB0w9pJJ0oT9BCKKJf16Tuj123vm1Ps0GOHSHmeWPgKM0zuViCVuTRpqaA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.6.0.tgz",
+      "integrity": "sha512-hYOJUI86N9+YPm0M3t8hVzW9t5FnFFibRalZCrqHs/qM2eNziqQzBtAaF0ErgkXm8F+5uE8CjPUYr32vWlXLkQ=="
     },
     "node_modules/lerc": {
       "version": "3.0.0",
@@ -20401,13 +20401,15 @@
       "version": "12.0.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cesium/engine": "^2.2.0",
-        "@cesium/widgets": "^2.1.1",
+        "@cesium/engine": "^3.0.2",
+        "@cesium/widgets": "^3.0.2",
         "@dlr-eoc/services-layers": "12.0.0-alpha.1",
         "@dlr-eoc/services-map-state": "12.0.0-alpha.1",
         "tslib": "^2.4.0"
       },
       "devDependencies": {
+        "@dlr-eoc/base-layers-raster": "12.0.0-alpha.1",
+        "@dlr-eoc/shared-assets": "12.0.0-alpha.1",
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "https-browserify": "^1.0.0",

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.html
@@ -16,7 +16,7 @@
         <clr-icon shape="block" clrVerticalNavIcon title="tilelayers"></clr-icon>
         3D Tilelayers
         <clr-vertical-nav-group-children class="padding title-ellipsis">
-            <ukis-layer-control [layersSvc]="threeDlayerSvc" [mapStateSvc]="mapStateSvc"></ukis-layer-control>
+            <ukis-layer-control [layersSvc]="threeDlayerSvc" [layersSort]="false" [mapStateSvc]="mapStateSvc"></ukis-layer-control>
         </clr-vertical-nav-group-children>
     </clr-vertical-nav-group>
 
@@ -32,7 +32,7 @@
         <clr-icon shape="world" title="Overlays" clrVerticalNavIcon></clr-icon>
         Overlays
         <clr-vertical-nav-group-children class="padding title-ellipsis">
-            <ukis-layer-control [layersSvc]="twoDlayerSvc" [mapStateSvc]="mapStateSvc" [layerfilter]="'Overlays'">
+            <ukis-layer-control [layersSvc]="twoDlayerSvc" [mapStateSvc]="mapStateSvc" [layersSort]="false" [layerfilter]="'Overlays'">
             </ukis-layer-control>
         </clr-vertical-nav-group-children>
     </clr-vertical-nav-group>

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
@@ -184,7 +184,7 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
         description: 'World Settlement Footprint Evolution',
         attribution: 'DLR/EOC: <a href="https://www.dlr.de/eoc/</a>',
         legendImg: 'https://geoservice.dlr.de/eoc/land/wms?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=WSF_Evolution',
-      })/* ,
+      }),
       new VectorLayer({
         id: 'kml_test',
         name: 'KML Vector Layer',
@@ -201,7 +201,7 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
         data: testData,
         visible: false,
         popup: true
-      }) */
+      })
     ];
 
     layers.map(l => this.twoDlayerSvc.addLayer(l, 'Overlays'));

--- a/projects/map-cesium/README.md
+++ b/projects/map-cesium/README.md
@@ -259,6 +259,7 @@ At the moment there are not many services out there, which serve 3D data. If you
 - Terrain has to be attributed with a new Cesium Credit object, see the example above. 
 - GeoJSON layer are supported, but they are always shown above imagery layers, regardless of their ordering index in the layer control. Therefore they should be added as overlays.
 - As of 01/2023, WFS is not supported by Cesium yet. 
+- KmlDataSource does not support opacity change at the moment
 
 
 ===

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@dlr-eoc/services-map-state": "12.0.0-alpha.1",
     "@dlr-eoc/services-layers": "12.0.0-alpha.1",
-    "@cesium/engine": "^2.2.0",
-    "@cesium/widgets": "^2.1.1",
+    "@cesium/engine": "^3.0.2",
+    "@cesium/widgets": "^3.0.2",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -90,6 +90,9 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
     /** clean up all events on destroy */
     this.subs.forEach(s => s.unsubscribe());
     if (this.viewer?.scene?.primitives) {
+      this.viewer.imageryLayers.removeAll();
+      this.viewer.dataSources.removeAll();
+      this.viewer.scene.primitives.removeAll();
       this.viewer.scene.primitives.destroy();
     }
     this.mapSvc.destroyLayerGrpoups();

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -260,6 +260,8 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mapSvc.update2DLayerVisibility(layers, filtertype);
     this.mapSvc.update2DLayerOpacity(layers, filtertype);
     this.mapSvc.update2DLayerZIndex(layers, filtertype);
+    this.mapSvc.updateDataSourceZIndex(layers, filtertype);
+
   }
 
   private addUpdate3DLayers(layers: Layer[], filtertype: Tgroupfiltertype) {

--- a/projects/map-cesium/src/lib/map-cesium.service.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { MapCesiumService } from './map-cesium.service';
 import { Viewer } from '@cesium/widgets';
 import { ICesiumControls } from './map-cesium.component';
-import { Scene } from '@cesium/engine';
+import { ImageryLayer, Scene } from '@cesium/engine';
 import { CustomLayer, ILayerOptions, IRasterLayerOptions, Layer, RasterLayer, VectorLayer, WmsLayer, WmtsLayer } from '@dlr-eoc/services-layers';
 
 import testFeatureCollection from '@dlr-eoc/shared-assets/geojson/testFeatureCollection.json';
@@ -434,7 +434,7 @@ describe('MapCesiumService ukisLayers', () => {
     const mapLayersLength = service.get2DImageryLayersSize('Layers');
     expect(mapLayersLength).toBe(layers.length);
 
-    const imageryLayer = service.getLayerById(ukisBaseLayer.id, 'Layers');
+    const imageryLayer = service.getLayerById(ukisBaseLayer.id, 'Layers') as ImageryLayer;
     expect(imageryLayer.show).toBe(ukisBaseLayer.visible);
     expect(imageryLayer.alpha).toBe(ukisBaseLayer.opacity);
   });
@@ -482,19 +482,19 @@ describe('MapCesiumService DataSources', () => {
     expect(service.getLayerById(ukisWmtsLayer.id, 'layers')).toBeTruthy();
   });
 
-  xit('should add geoJSON DataSource', () => {
+  it('should add geoJSON DataSource', () => {
     service.createMap(mapTarget.container);
     service.set2DUkisLayers([ukisGeoJsonLayer], 'Layers');
 
-    expect(service.get2DImageryLayersSize('Layers')).toBe(1);
+    expect(service.getAll2DLayersSize('Layers')).toBe(1);
     expect(service.getLayerById(ukisGeoJsonLayer.id, 'layers')).toBeTruthy();
   });
 
-  xit('should add KML DataSource', () => {
+  it('should add KML DataSource', () => {
     service.createMap(mapTarget.container);
     service.set2DUkisLayers([ukisKmlLayer], 'Layers');
 
-    expect(service.get2DImageryLayersSize('Layers')).toBe(1);
+    expect(service.getAll2DLayersSize('Layers')).toBe(1);
     expect(service.getLayerById(ukisKmlLayer.id, 'layers')).toBeTruthy();
   });
 

--- a/projects/map-cesium/src/lib/map-cesium.service.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.spec.ts
@@ -486,7 +486,7 @@ describe('MapCesiumService DataSources', () => {
     service.createMap(mapTarget.container);
     service.set2DUkisLayers([ukisGeoJsonLayer], 'Layers');
 
-    expect(service.getAll2DLayersSize('Layers')).toBe(1);
+    expect(service.getDataSourceLayersSize('Layers')).toBe(1);
     expect(service.getLayerById(ukisGeoJsonLayer.id, 'layers')).toBeTruthy();
   });
 
@@ -494,7 +494,7 @@ describe('MapCesiumService DataSources', () => {
     service.createMap(mapTarget.container);
     service.set2DUkisLayers([ukisKmlLayer], 'Layers');
 
-    expect(service.getAll2DLayersSize('Layers')).toBe(1);
+    expect(service.getDataSourceLayersSize('Layers')).toBe(1);
     expect(service.getLayerById(ukisKmlLayer.id, 'layers')).toBeTruthy();
   });
 

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -287,6 +287,19 @@ export class MapCesiumService {
     return length;
   }
 
+  public getDataSourceLayersSize(filtertype: Tgroupfiltertype): number {
+    const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
+    let length = 0;
+    if (lowerType === 'baselayers') {
+      length = this.baseLayerDataSourceGroup.size;
+    } else if (lowerType === 'layers') {
+      length = this.standardLayerDataSourceGroup.size;
+    } else if (lowerType === 'overlays') {
+      length = this.overlayLayerDataSourceGroup.size;
+    }
+    return length;
+  }
+
   public getVisible2DLayersSize(filtertype: Tgroupfiltertype): number {
     const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
     let length = 0;
@@ -788,11 +801,11 @@ export class MapCesiumService {
 
   public update2DLayerOpacity(layers: Layer[], filtertype: Tgroupfiltertype) {
     const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
-    for (const layer of layers) {
+
       if (lowerType === 'baselayers') {
+        for (const layer of layers) {
         if (this.baseLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.baseLayerImageryGroup.get(layer.id);
-
           if (viewerLayer && viewerLayer.alpha !== layer.opacity) {
             viewerLayer.alpha = layer.opacity;
           }
@@ -807,7 +820,9 @@ export class MapCesiumService {
             this.dataSourceOpacity.set(layer.id, layer.opacity);
           }
         }
+      }
       } else if (lowerType === 'layers') {
+        for (const layer of layers) {
         if (this.standardLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.standardLayerImageryGroup.get(layer.id);
 
@@ -825,7 +840,9 @@ export class MapCesiumService {
             this.dataSourceOpacity.set(layer.id, layer.opacity);
           }
         }
+      }
       } else if (lowerType === 'overlays') {
+        for (const layer of layers) {
         if (this.overlayLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.overlayLayerImageryGroup.get(layer.id);
 
@@ -899,9 +916,10 @@ export class MapCesiumService {
 
   public update2DLayerZIndex(layers: Layer[], filtertype: Tgroupfiltertype) {
     const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
-    for (const layer of layers) {
-      const layerCollection = this.viewer.imageryLayers;
+    const layerCollection = this.viewer.imageryLayers;
+
       if (lowerType === 'baselayers') {
+        for (const layer of layers) {
         if (this.baseLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.baseLayerImageryGroup.get(layer.id);
           if (viewerLayer) {
@@ -923,7 +941,9 @@ export class MapCesiumService {
             }
           }
         }
+      }
       } else if (lowerType === 'layers') {
+        for (const layer of layers) {
         if (this.standardLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.standardLayerImageryGroup.get(layer.id);
           if (viewerLayer) {
@@ -946,8 +966,10 @@ export class MapCesiumService {
               }
             }
           }
+          }
         }
       } else if (lowerType === 'overlays') {
+        for (const layer of layers) {
         if (this.overlayLayerImageryGroup.has(layer.id)) {
           const viewerLayer = this.overlayLayerImageryGroup.get(layer.id);
           if (viewerLayer) {
@@ -969,10 +991,95 @@ export class MapCesiumService {
             }
           }
         }
-      }
+        }
     }
 
   }
+
+  public updateDataSourceZIndex(layers: Layer[], filtertype: Tgroupfiltertype) {
+    const dataSourceCollection = this.viewer.dataSources;
+    if(dataSourceCollection.length>1){
+    const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
+      if (lowerType === 'baselayers') {
+        for (const layer of layers) {
+        if (this.baseLayerDataSourceGroup.has(layer.id)) {
+          const viewerLayer = this.baseLayerDataSourceGroup.get(layer.id);
+          if (viewerLayer) {
+            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+            const layerIndex = layers.indexOf(layer);
+            if (cesiumIndex !== layerIndex) {
+              const diffIndex = cesiumIndex - layerIndex;
+              if (diffIndex < 0) {
+                // Move layer up in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.raise(viewerLayer);
+                }
+              } else if (diffIndex > 0) {
+                // Move layer down in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.lower(viewerLayer);
+                }
+              }
+            }
+          }
+          }
+        }
+      } else if (lowerType === 'layers') {
+        for (const layer of layers) {
+        if (this.standardLayerDataSourceGroup.has(layer.id)) {
+          const viewerLayer = this.standardLayerDataSourceGroup.get(layer.id);
+          if (viewerLayer) {
+            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+            const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers');
+            if (cesiumIndex !== layerIndex) {
+              const diffIndex = cesiumIndex - layerIndex;
+              if (diffIndex < 0) {
+                // Move layer up in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.raise(viewerLayer);
+                }
+              } else if (diffIndex > 0) {
+                // Move layer down in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.lower(viewerLayer);
+                }
+              }
+            }
+          }
+          }
+        }
+      } else if (lowerType === 'overlays') {
+        for (const layer of layers) {
+        if (this.overlayLayerDataSourceGroup.has(layer.id)) {
+          const viewerLayer = this.overlayLayerDataSourceGroup.get(layer.id);
+          if (viewerLayer) {
+            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+            const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers') + this.getDataSourceLayersSize('layers');
+/*             console.log(layer.name);
+            console.log('CesiumIndex: '+ cesiumIndex);
+            console.log('LayerIndex: '+ layerIndex); */
+            if (cesiumIndex !== layerIndex && cesiumIndex >= 0){
+              const diffIndex = cesiumIndex - layerIndex;
+              if (diffIndex < 0) {
+                // Move layer up in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.raise(viewerLayer);
+                }
+              } else if (diffIndex > 0) {
+                // Move layer down in collection
+                for (let i = 0; i < Math.abs(diffIndex); i++) {
+                  dataSourceCollection.lower(viewerLayer);
+                }
+              }
+              //console.log('New CesiumIndex: '+ dataSourceCollection.indexOf(viewerLayer));
+            }
+          }
+        }
+      }
+    }
+  }
+  }
+
 
   //Adding terrain provider from Layer
   public setTerrain(terrainLayer: CustomLayer) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)
- [ x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
At the moment DataSources like geoJSON or KML are not displayed correctly on the cesium globe. There seems to be some interference with the handling of primitive datasets like tilesets.

Issue Number: #197 

## What is the new behavior?
Vector DataSources are displayed correctly. The issue was fixed by seperating the handling of cesium primitives and datasources.
Cesium dependencies were updated in the process. Vector DataSOurces were added to the demo-maps cesium example.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


## Other information
Affects map-cesium and demo-maps
