### PR TITLE
Projection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   - The dynamic popup now gets `IPopupParams` instead of `IDynamicPopupArgs` - `popup.dynamicPopup.getAttributes(params:IPopupParams)`
   - Not used `notifier` is removed from `MapOlService.setZoom(zoom: number)`
 
+* **@dlr-eoc/map-tools:**
+  - Input 'mapSvc' of ProjectionSwitchComponent become mandatory and not optional
+  - Additional mandatory input in ProjectionSwitchComponent "mapStateSvc" and optional "fitViewToNewExtent"
+
 ### Features
 * **@dlr-eoc/map-cesium:**
   - New UKIS library for working with [CesiumJS](https://github.com/CesiumGS/cesium) was added.
@@ -19,6 +23,9 @@
   - Popup events can be observed by `MapOlService.popupEvents: Subject<IPopupEvent>`. For this add `asObservable: true` to a popup object, you will then be able to subscribe to the event instead of having a popup container being added to the map.
   - A new Interface `IPopupEvent` is exposed.
   - Add groupID to olLayers (layer.groupID) to check if a layer was in an olLayerGroup.
+
+* **@dlr-eoc/map-tools:**
+  - Optional parameter "fitViewToNewExtent" in the ProjectionSwitchComponent to adjust map view extent
 
 # [11.1.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v11.1.0) (2023-05-30) (map-ol and layer-control)
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -20408,6 +20408,8 @@
         "tslib": "^2.4.0"
       },
       "devDependencies": {
+        "@dlr-eoc/base-layers-raster": "12.0.0-alpha.1",
+        "@dlr-eoc/shared-assets": "12.0.0-alpha.1",
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "https-browserify": "^1.0.0",

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
@@ -14,7 +14,7 @@
     <clr-icon shape="map" clrVerticalNavIcon></clr-icon>
     Projection
     <clr-vertical-nav-group-children class="padding title-ellipsis">
-      <ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections"></ukis-projection-switch>
+      <ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections" [fitViewToNewExtent]="true" [mapStateSvc]="mapStateSvc"></ukis-projection-switch>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers" title="Coordinates">

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -34,7 +34,7 @@ export class RouteMap2Component implements OnInit {
       title: 'Arctic Polar Stereographic',
       extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
       worldExtent: [-180.0, 60.0, 180.0, 90.0],
-      global: false,
+      global: true,
       units: 'm'
     };
 
@@ -44,7 +44,7 @@ export class RouteMap2Component implements OnInit {
       title: 'Antarctic Polar Stereographic',
       extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
       worldExtent: [-180.0, -90.0, 180.0, -60.0],
-      global: false,
+      global: true,
       units: 'm'
     };
 

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -50,9 +50,9 @@ export class RouteMap2Component implements OnInit {
 
     const webMercator: IProjDef = {
       code: `EPSG:3857`,
-      proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs',
+      proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
       title: 'Spherical Mercator',
-      extent: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
+      extent: [-20037508.34, -20048966.1, 20037508.34, 20048966.1],
       worldExtent: [-180.0, -85.06, 180.0, 85.06],
       global: true,
       units: 'm'

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -30,9 +30,9 @@ export class RouteMap2Component implements OnInit {
 
     const arcticPolarStereographic: IProjDef = {
       code: 'EPSG:3995',
-      proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
+      proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
       title: 'Arctic Polar Stereographic',
-      extent: [-20048966.10, -20048966.10, 20048966.10, 20048966.10],
+      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
       worldExtent: [-180.0, 60.0, 180.0, 90.0],
       global: false,
       units: 'm'
@@ -40,9 +40,9 @@ export class RouteMap2Component implements OnInit {
 
     const antarcticPolarStereographic: IProjDef = {
       code: `EPSG:3031`,
-      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
+      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
       title: 'Antarctic Polar Stereographic',
-      extent: [-20048966.10, -20048966.10, 20048966.10, 20048966.10],
+      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
       worldExtent: [-180.0, -90.0, 180.0, -60.0],
       global: false,
       units: 'm'

--- a/projects/map-tools/README.md
+++ b/projects/map-tools/README.md
@@ -101,7 +101,7 @@ addBaselayers() {
     <clr-icon shape="map" clrVerticalNavIcon></clr-icon>
     Projection
     <clr-vertical-nav-group-children class="padding title-ellipsis">
-      <ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections"></ukis-projection-switch>
+      <ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections" [fitViewToNewExtent]="true" [mapStateSvc]="mapStateSvc"></ukis-projection-switch>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
 ```

--- a/projects/map-tools/README.md
+++ b/projects/map-tools/README.md
@@ -117,31 +117,31 @@ constructor(
     public mapStateSvc: MapStateService
 ) { 
 
-    let arcticPolarStereographic:IProjDef = {
+    const arcticPolarStereographic: IProjDef = {
       code: 'EPSG:3995',
-      proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
+      proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
       title: 'Arctic Polar Stereographic',
-      extent: [-20048966.10, -20048966.10, 20048966.10, 20048966.10],
+      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
       worldExtent: [-180.0, 60.0, 180.0, 90.0],
-      global: false,
+      global: true,
       units: 'm'
     };
 
-    let antarcticPolarStereographic:IProjDef = {
+    const antarcticPolarStereographic: IProjDef = {
       code: `EPSG:3031`,
-      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
+      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
       title: 'Antarctic Polar Stereographic',
-      extent: [-20048966.10, -20048966.10, 20048966.10, 20048966.10],
-      worldExtent: [-180.0, -90.0, 180.0, -60.0 ],
-      global: false,
+      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
+      worldExtent: [-180.0, -90.0, 180.0, -60.0],
+      global: true,
       units: 'm'
     };
 
-    let webMercator:IProjDef = {
+    const webMercator: IProjDef = {
       code: `EPSG:3857`,
-      proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs',
+      proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
       title: 'Spherical Mercator',
-      extent: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
+      extent: [-20037508.34, -20048966.1, 20037508.34, 20048966.1],
       worldExtent: [-180.0, -85.06, 180.0, 85.06],
       global: true,
       units: 'm'

--- a/projects/map-tools/src/lib/projection-switch/projection-switch.component.ts
+++ b/projects/map-tools/src/lib/projection-switch/projection-switch.component.ts
@@ -2,15 +2,20 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MapOlService } from '@dlr-eoc/map-ol';
 
+import { MapStateService } from '@dlr-eoc/services-map-state';
+
+
 
 @Component({
   selector: 'ukis-projection-switch',
   templateUrl: './projection-switch.component.html',
-  styles: []
+  styles: [],
 })
 export class ProjectionSwitchComponent implements OnInit {
   @Input('mapSvc') mapSvc?: MapOlService;
+  @Input('mapStateSvc') mapStateSvc: MapStateService;
   @Input('projectionList') projList: IProjDef[];
+  @Input('fitViewToNewExtent') fitViewToNewExtent? = false;
   subscription: Subscription;
   selectedProj: IProjDef;
   constructor() { }
@@ -23,10 +28,11 @@ export class ProjectionSwitchComponent implements OnInit {
 
   setNewProjection(projection: IProjDef) {
     this.mapSvc.registerProjection(projection);
-
     const newProj = this.mapSvc.getOlProjection(projection);
-
     this.mapSvc.setProjection(newProj);
+    if (this.fitViewToNewExtent) {
+      this.mapStateSvc.setExtent(projection.worldExtent);
+    }
     this.selectedProj = projection;
   }
 }

--- a/projects/map-tools/src/lib/projection-switch/projection-switch.component.ts
+++ b/projects/map-tools/src/lib/projection-switch/projection-switch.component.ts
@@ -12,7 +12,7 @@ import { MapStateService } from '@dlr-eoc/services-map-state';
   styles: [],
 })
 export class ProjectionSwitchComponent implements OnInit {
-  @Input('mapSvc') mapSvc?: MapOlService;
+  @Input('mapSvc') mapSvc: MapOlService;
   @Input('mapStateSvc') mapStateSvc: MapStateService;
   @Input('projectionList') projList: IProjDef[];
   @Input('fitViewToNewExtent') fitViewToNewExtent? = false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Wrong projection defs led to error messages described in #199 

Issue Number: #199


## What is the new behavior?

- fixed of projections defs in demo-maps/projections. 

- included option to fit view extent to the new projection. This is helpful e.g. when in one map user publish several different projections that do not cover common areas like Arctic and Antarctic Polar projection, in this case it make sense to navigate to the extent of the newly selected projection. This feature is optional and it is up to user to use it
`
<ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections" [fitViewToNewExtent]="true" [mapStateSvc]="mapStateSvc"></ukis-projection-switch>
    </clr-vertical-nav-group-children>
`


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
minor breaking change that should not affect much. The demo-map has been updated.
* **@dlr-eoc/map-tools:**
  - Input 'mapSvc' of ProjectionSwitchComponent become mandatory and not optional
  - Additional mandatory input in ProjectionSwitchComponent "mapStateSvc" and optional "fitViewToNewExtent"

