### PR TITLE
Mapstate update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
   - Test for incorrect values in setters
 
 * **@dlr-eoc/map-ol:**
-  - Adding support for mapState rotation  
+
 * **@dlr-eoc/map-cesium:**
   - Adding support for mapState viewAngle and rotation
+  - Added flyTo options for `setViewAngle` and `setRotation`
+
  * **@dlr-eoc/map-maplibre:**
   - Adding support for mapState viewAngle and rotation 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-# [12.x.x](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2024-02-07) (services-map-state)
+# [12.x.x](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2024-02-07) (services-map-state, map-ol, map-cesium and map-maplibre)
 ### Features
 * **@dlr-eoc/services-map-state:**
   - Added viewAngle and rotation to mapState [Issue #216](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/216).
+* **@dlr-eoc/map-ol:**
+  - Adding support for mapState rotation  
+* **@dlr-eoc/map-cesium:**
+  - Adding support for mapState viewAngle and rotation
+ * **@dlr-eoc/map-maplibre:**
+  - Adding support for mapState viewAngle and rotation 
   
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
  * **@dlr-eoc/map-maplibre:**
   - Fix wrong coordinate order from `getExtent` [#216](7ff01801fd3af594aaa34b2479e921be88894dbe)
   - Rename `set/getBearing` to `set/getRotation` because we want to have the same behavior as in openlayers and `set/getBearing` is expected differently in mapliebre
+
+* **@dlr-eoc/map-cesium:**
+  - Fix get entity.name for infoBox in none GeoJson layers
   
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# [12.x.x](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2024-02-07) (services-map-state, map-ol, map-cesium and map-maplibre)
+# [12.x.x]() () (services-map-state, map-ol, map-cesium and map-maplibre)
+
+
 ### Features
 * **@dlr-eoc/services-map-state:**
   - Added viewAngle and rotation to mapState [Issue #216](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/216).
@@ -11,6 +13,7 @@
 * **@dlr-eoc/map-cesium:**
   - Adding support for mapState viewAngle and rotation
   - Added flyTo options for `setViewAngle` and `setRotation`
+  - Added flyTo options for `setNadirViewAngle` - This can be useful if you switch the map to a 2D view and want to reset the `ViewAngle` before.
 
  * **@dlr-eoc/map-maplibre:**
   - Adding support for mapState viewAngle and rotation 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [12.x.x](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2024-02-07) (services-map-state)
+### Features
+* **@dlr-eoc/services-map-state:**
+  - Added viewAngle and rotation to mapState [Issue #216](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/216).
+  
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes
   - Update angular from `^14.2.11` to `^16.2.1` automatic migrations are made by ng update. See update angular from [14.0-15.0](https://update.angular.io/?l=3&v=14.0-15.0) and [14.0-15.0](https://update.angular.io/?l=3&v=15.0-16.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Features
 * **@dlr-eoc/services-map-state:**
   - Added viewAngle and rotation to mapState [Issue #216](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/216).
+  - Added optional `notifier`  to `setTime` like in the setters  `setExtent`, `setViewAngle` or `setRotation`.
+  - Test for incorrect values in setters
+
 * **@dlr-eoc/map-ol:**
   - Adding support for mapState rotation  
 * **@dlr-eoc/map-cesium:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   - Adding support for mapState viewAngle and rotation
  * **@dlr-eoc/map-maplibre:**
   - Adding support for mapState viewAngle and rotation 
+
+### Bug Fixes
+ * **@dlr-eoc/map-maplibre:**
+  - Fix wrong coordinate order from `getExtent` [#216](7ff01801fd3af594aaa34b2479e921be88894dbe)
   
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Test for incorrect values in setters
 
 * **@dlr-eoc/map-ol:**
+  - Adding support for mapState rotation [#216](e04b42fd62c4b66fc21920a514da1375bb297a11)
 
 * **@dlr-eoc/map-cesium:**
   - Adding support for mapState viewAngle and rotation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * **@dlr-eoc/map-cesium:**
   - Fix get entity.name for infoBox in none GeoJson layers
+  - Get camera view and set `Mapstate` before destroy to preserve the last state for switching maps.
   
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
  * **@dlr-eoc/map-maplibre:**
   - Fix wrong coordinate order from `getExtent` [#216](7ff01801fd3af594aaa34b2479e921be88894dbe)
+  - Rename `set/getBearing` to `set/getRotation` because we want to have the same behavior as in openlayers and `set/getBearing` is expected differently in mapliebre
   
 # [12.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v12.0.0) (2023-12-12) (map-ol, map-cesium and map-maplibre)
 ### Breaking Changes

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.html
@@ -53,6 +53,19 @@
         </clr-vertical-nav-group-children>
     </clr-vertical-nav-group>
 
+    <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers">
+      <clr-icon shape="cog" title="Actions" clrVerticalNavIcon></clr-icon>
+      Actions
+      <clr-vertical-nav-group-children class="padding title-ellipsis">
+
+        <button class="btn btn-primary" (click)="setViewAngle()">set ViewAngle</button>
+        <button class="btn btn-primary" (click)="resetViewAngle()">reset ViewAngle</button>
+        <button class="btn btn-primary" (click)="setRotation()">set Rotation</button>
+        <button class="btn btn-primary" (click)="resetRotation()">reset Rotation</button>
+
+      </clr-vertical-nav-group-children>
+    </clr-vertical-nav-group>
+
     <a clrVerticalNavLink *ngIf="is2dMap" class="iconButton" (click)="changeMapDimension()">
         <clr-icon shape="block" title="3D View" clrVerticalNavIcon></clr-icon>
         3D View

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
@@ -3,9 +3,8 @@ import { LayersService, Layer, WmtsLayer, RasterLayer, CustomLayer, WmsLayer, Ve
 import { MapStateService, IMapState } from '@dlr-eoc/services-map-state';
 
 import { OsmTileLayer, EocLitemap, BlueMarbleTile, EocLiteoverlayTile } from '@dlr-eoc/base-layers-raster';
-import { ICesiumControls } from '@dlr-eoc/map-cesium';
+import { ICesiumControls, MapCesiumService } from '@dlr-eoc/map-cesium';
 import { MapOlService } from '@dlr-eoc/map-ol';
-import olMap from 'ol/Map';
 import { Cesium3DTileset, CesiumTerrainProvider, Credit, EllipsoidTerrainProvider, I3SDataProvider, createGooglePhotorealistic3DTileset } from '@cesium/engine';
 import testData from '@dlr-eoc/shared-assets/geojson/test.json';
 import { Feature } from 'ol';
@@ -20,6 +19,7 @@ import { Fill, Stroke, Style } from 'ol/style';
   providers: [
     MapStateService,
     MapOlService,
+    MapCesiumService,
     {
       provide: 'twoDlayerSvc', useClass: LayersService
     }, {
@@ -48,7 +48,8 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
     @Inject('twoDlayerSvc') public twoDlayerSvc: LayersService,
     @Inject('threeDlayerSvc') public threeDlayerSvc: LayersService,
     public mapOlSvc: MapOlService,
-    public mapStateSvc: MapStateService
+    public mapStateSvc: MapStateService,
+    public mapCesiumSvc: MapCesiumService
   ) {
     this.controls = {
       infoBox: true,
@@ -310,21 +311,11 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
     if (this.is2dMap) {
       this.is2dMap = false;
     } else {
-      // If there is no set view angle, the flyTo is not necessary
-      if (this.mapStateSvc.getMapState().getValue().viewAngle != 0) {
-        this.mapStateSvc.setViewAngle(0.01);
-        // Wait for the cesim flyTo function to finish
-        setTimeout(() => {
-          //the openlayers map needs to be fully resetted, to avoid an error with the map controls
-          this.mapOlSvc.map = new olMap({});
+      this.mapCesiumSvc.setNadirViewAngle({
+        complete: () => {
           this.is2dMap = true;
-        }, 1500);
-      } else {
-        this.mapOlSvc.map = new olMap({});
-        this.is2dMap = true;
-      }
-
-
+        }
+      });
     }
   }
 

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
@@ -327,21 +327,22 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
 
     }
   }
+
   setViewAngle() {
     /** set map rotation with the MapStateService */
     this.mapStateSvc.setViewAngle(45);
   }
   resetViewAngle() {
     /** set map rotation with the MapStateService */
-    this.mapStateSvc.setViewAngle(0.01);
+    this.mapStateSvc.setViewAngle(0);
   }
   setRotation() {
     /** set map rotation with the MapStateService */
-    this.mapStateSvc.setRotation(90);
+    this.mapStateSvc.setRotation(10);
   }
   resetRotation() {
     /** set map rotation with the MapStateService, due to the rotation constraint small numbers are snapped to 0 */
-    this.mapStateSvc.setRotation(0.01);
+    this.mapStateSvc.setRotation(0);
   }
 }
 

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.html
@@ -41,6 +41,8 @@
 
       <button class="btn btn-primary" (click)="removeAllLayers()">remove All Layers</button>
       <button class="btn btn-primary" (click)="setExtent()">set Extent</button>
+      <button class="btn btn-primary" (click)="setRotation()">set Rotation</button>
+      <button class="btn btn-primary" (click)="resetRotation()">reset Rotation</button>
 
       <button class="btn btn-primary" (click)="parseCapabilities()">Parse WMS capabilities</button>
 

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -59,7 +59,7 @@ export class RouteMapComponent implements OnInit {
   }
   resetRotation() {
     /** set map rotation with the MapStateService, due to the rotation constraint small numbers are snapped to 0 */
-    this.mapStateSvc.setRotation(0.01);
+    this.mapStateSvc.setRotation(0);
   }
 
   parseCapabilities() {

--- a/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-layers/route-map.component.ts
@@ -53,6 +53,14 @@ export class RouteMapComponent implements OnInit {
     /** set map extent or IMapState (zoom, center...) with the MapStateService */
     this.mapStateSvc.setExtent([-14, 33, 40, 57]);
   }
+  setRotation() {
+    /** set map rotation with the MapStateService */
+    this.mapStateSvc.setRotation(90);
+  }
+  resetRotation() {
+    /** set map rotation with the MapStateService, due to the rotation constraint small numbers are snapped to 0 */
+    this.mapStateSvc.setRotation(0.01);
+  }
 
   parseCapabilities() {
     this.wmsSvc.getCapabilities('https://geoservice.dlr.de/eoc/land/wms').subscribe(caps => {

--- a/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.html
@@ -35,6 +35,10 @@
     <clr-vertical-nav-group-children class="padding title-ellipsis">
 
       <button class="btn btn-primary" (click)="updateLayer()">update Geojson Layer</button>
+      <button class="btn btn-primary" (click)="setViewAngle()">set ViewAngle</button>
+      <button class="btn btn-primary" (click)="resetViewAngle()">reset ViewAngle</button>
+      <button class="btn btn-primary" (click)="setRotation()">set Rotation</button>
+      <button class="btn btn-primary" (click)="resetRotation()">reset Rotation</button>
 
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>

--- a/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.ts
@@ -721,7 +721,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
   }
   resetViewAngle() {
     /** set map rotation with the MapStateService */
-    this.mapStateSvc.setViewAngle(0.01);
+    this.mapStateSvc.setViewAngle(0);
   }
   setRotation() {
     /** set map rotation with the MapStateService */
@@ -729,7 +729,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
   }
   resetRotation() {
     /** set map rotation with the MapStateService, due to the rotation constraint small numbers are snapped to 0 */
-    this.mapStateSvc.setRotation(0.01);
+    this.mapStateSvc.setRotation(0);
   }
 
 }

--- a/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-maplibre/route-example-maplibre.component.ts
@@ -48,9 +48,13 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
       lat: 47.41449812198263,
       lon: 11.7455863952639
     };
+    const rotation = 45;
+    const viewAngle = 60;
     this.mapStateSvc.setMapState({
       zoom,
-      center
+      center,
+      rotation,
+      viewAngle
     });
   }
 
@@ -87,8 +91,6 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
           exaggeration: exaggeration
         });
 
-        map.setBearing(-20);
-        map.setPitch(60);
         map.setMaxPitch(80);
 
         map.addControl(
@@ -103,7 +105,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
   }
 
   addBaselayers() {
-    // some of the fonts are not working 
+    // some of the fonts are not working
     greyscale.layers.forEach(l => {
       if (l?.layout?.['text-font']) {
         l.layout['text-font'] = l.layout['text-font'].filter(i => i !== 'Noto Sans Regular' && i !== 'Noto Sans Italic');
@@ -231,7 +233,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
     const sentinel2Europe = new WmsLayer({
       name: 'Sentinel-2 Europe',
       id: 'sentinel2Europe',
-      visible: false,
+      visible: true,
       type: 'wms',
       removable: false,
       params: {
@@ -249,7 +251,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
     const mosaic_hillshade = new WmsLayer({
       name: 'mosaic_hillshade',
       id: 'gmted2010_dsc075_mosaic_hillshade',
-      visible: true,
+      visible: false,
       type: 'wms',
       removable: false,
       params: {
@@ -551,7 +553,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
       id: 'group_1',
       name: 'Raster Group',
       visible: false,
-      layers: [eocBasemap, osm, MODIS_EU_DAILY, sentinel2Europe],
+      layers: [eocBasemap, osm, MODIS_EU_DAILY, hillshade, mosaic_hillshade],
       description: 'This is a group with multiple raster layers',
       expanded: {
         tab: 'description'
@@ -560,7 +562,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
     });
 
 
-    const layers = [groupLayer, hillshade, mosaic_hillshade, waterway, wfsLayer, kmlLayer, geoJsonLayer, stackedLayer, agrodeLayer];
+    const layers = [groupLayer, ,sentinel2Europe, waterway, wfsLayer, kmlLayer, geoJsonLayer, stackedLayer, agrodeLayer];
     layers.map(l => {
       if (l instanceof Layer) {
         this.layerSvc.addLayer(l, 'Layers');
@@ -629,7 +631,7 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
       opacity: 1
     });
 
-    // some of the fonts are not working 
+    // some of the fonts are not working
     placeLabels.layers.forEach(l => {
       l.source = 'place-labels-planet_eoc';
       if (l?.layout?.['text-font']) {
@@ -712,6 +714,22 @@ export class RouteExampleMaplibreComponent implements OnInit, OnDestroy {
       ]
     };
     this.layerSvc.updateLayer(layer);
+  }
+  setViewAngle() {
+    /** set map rotation with the MapStateService */
+    this.mapStateSvc.setViewAngle(45);
+  }
+  resetViewAngle() {
+    /** set map rotation with the MapStateService */
+    this.mapStateSvc.setViewAngle(0.01);
+  }
+  setRotation() {
+    /** set map rotation with the MapStateService */
+    this.mapStateSvc.setRotation(90);
+  }
+  resetRotation() {
+    /** set map rotation with the MapStateService, due to the rotation constraint small numbers are snapped to 0 */
+    this.mapStateSvc.setRotation(0.01);
   }
 
 }

--- a/projects/map-cesium/src/lib/map-cesium.component.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.spec.ts
@@ -6,7 +6,7 @@ import { MapCesiumService } from './map-cesium.service';
 import { MapStateService } from '@dlr-eoc/services-map-state';
 import { Viewer } from '@cesium/widgets';
 import { Component, Injectable, Input, OnDestroy, OnInit } from '@angular/core';
-import { of } from 'rxjs';
+import { of, timeout } from 'rxjs';
 import { OsmTileLayer, EocBasemapTile } from '@dlr-eoc/base-layers-raster';
 
 /**
@@ -181,6 +181,24 @@ describe('MapCesiumComponent', () => {
   it('should have a viewer and the viewer should be the same as from the mapSvc', () => {
     expect(component.viewer instanceof Viewer).toBeTruthy();
     expect(component.viewer === mapSvc.viewer).toBeTruthy();
+  });
+
+  it('should set mapstate rotation', async () => {
+    //set rotation to 90°
+    component.mapStateSvc.setRotation(90);
+    // we have to wait for the flyTo to finish
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    // some radians to degree conversions are made, so there are some rounding errors to be expected
+    expect(mapSvc.getRotation()).toBeCloseTo(90);
+  });
+
+  it('should set mapstate view angle', async () => {
+    //set view angle to 55°
+    component.mapStateSvc.setViewAngle(55);
+    // we have to wait for the flyTo to finish
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    // some radians to degree conversions are made, so there are some rounding errors to be expected
+    expect(mapSvc.getViewAngle()).toBeCloseTo(55);
   });
 
   it('should add Imagery layers', () => {

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -89,7 +89,9 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-
+    /**
+     * Set the last MapState on Destroy. When the component is reinitialized, this MapState is used
+     */
     const lastMapState = this.mapStateSvc.getMapState().value;
     lastMapState.options.notifier = 'user';
     this.mapStateSvc.setMapState(lastMapState);

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -76,6 +76,7 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
 
     /** Get last state from mapStateSvc and set it, so a User can set the initial MapState in a component */
     const oldMapState = this.mapStateSvc.getMapState().getValue();
+    oldMapState.options.notifier = 'user';
     this.setMapState(oldMapState);
     // set viewAngle and rotation seperatly again, as their values are not set by the viewer the first time
     this.mapSvc.setViewAngle(oldMapState.viewAngle);

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -192,7 +192,7 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
       const titleDiv = this.viewer.infoBox.container.getElementsByClassName('cesium-infoBox-title')[0];
       titleDiv.innerHTML = 'Layer Attributes';
       if (entity) {
-        if(entity.entityCollection.owner instanceof GeoJsonDataSource){
+        if(entity.entityCollection?.owner instanceof GeoJsonDataSource){
           titleDiv.innerHTML = entity.entityCollection.owner.name;
           entity.name = entity.entityCollection.owner.name;
         }else{

--- a/projects/map-cesium/src/lib/map-cesium.service.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.spec.ts
@@ -235,21 +235,24 @@ describe('MapCesiumService State', () => {
     expect(service.getCurrentExtent(true) !== oldExtent).toBeTrue();
   });
 
-
-  it('should set the view angle', () => {
+  it('should set/get rotation', async () => {
     service.createMap(mapTarget.container);
-    const oldAngle = service.viewer.camera.roll;
-    const newAngle = 20;
-
-    service.setViewAngle(newAngle);
-    expect(service.viewer.camera.roll !== oldAngle).toBeTrue();
+    const newRotation = 45;
+    service.setRotation(newRotation);
+    // we have to wait for the flyTo to finish
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    // some radians to degree conversions are made, so there are some rounding errors to be expected
+    expect(service.getRotation()).toBeCloseTo(45);
   });
 
-  it('should set the nadir view angle', () => {
+  it('should set/get view angle', async () => {
     service.createMap(mapTarget.container);
-
-    service.setNadirViewAngle();
-    expect(service.viewer.camera.roll === 0).toBeTrue();
+    const newAngle = 45;
+    service.setViewAngle(newAngle);
+    // we have to wait for the flyTo to finish
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    // some radians to degree conversions are made, so there are some rounding errors to be expected
+    expect(service.getViewAngle()).toBeCloseTo(45);
   });
 
 });

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -244,8 +244,22 @@ export class MapCesiumService {
     this.viewer.camera.flyTo(flyToOptions)
   }
 
-  public setNadirViewAngle() {
-    this.setViewAngle(0);
+  /**
+   * @param options of viewer.camera.flyTo
+   */
+  public setNadirViewAngle(options?: any) {
+    if (this.getViewAngle() !== 0) {
+      if (options) {
+        this.setViewAngle(0, options);
+      } else {
+        this.setViewAngle(0);
+      }
+    }else{
+      // If view angle is 0, setViewAngle(0) (flyTo) is not necessary
+      if(options.complete && typeof options.complete === 'function'){
+        options.complete();
+      }
+    }
   }
 
   //add 90°, to get the same behavior as in openlayers
@@ -272,7 +286,7 @@ export class MapCesiumService {
 
     this.viewer.camera.flyTo(flyToOptions)
   }
-// subtract rotation degree from 360° to get the same behavior as in openlayers
+  // subtract rotation degree from 360° to get the same behavior as in openlayers
   public getRotation():number{
     return 360 - CesiumMath.toDegrees(this.viewer.camera.heading);
   }

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -223,17 +223,25 @@ export class MapCesiumService {
     return extent;
   }
 
-  // Set initial oblique view, see https://cesium.com/learn/cesiumjs/ref-doc/Camera.html
-  //subtract 90°, to get the same behavior as in openlayers
-  public setViewAngle(viewAngle: number) {
-    this.viewer.camera.flyTo({
+  /**
+    *  Set initial oblique view, see https://cesium.com/learn/cesiumjs/ref-doc/Camera.html
+    *  subtract 90°, to get the same behavior as in openlayers
+    *  options of viewer.camera.flyTo`
+    * 
+    * https://github.com/CesiumGS/cesium/blob/99d6fffe20d9cf19f2d70de97777dc00a435bc5e/packages/engine/Source/Scene/Camera.js#L1457
+    * https://github.com/CesiumGS/cesium/blob/99d6fffe20d9cf19f2d70de97777dc00a435bc5e/packages/engine/Source/Scene/Camera.js#L3540-L3541
+    */
+  public setViewAngle(viewAngle: number, options?: any) {
+    const flyToOptions = Object.assign({
       destination: this.viewer.camera.position,
       orientation: {
         heading: this.viewer.camera.heading,
-        pitch: CesiumMath.toRadians(viewAngle-90),
+        pitch: CesiumMath.toRadians(viewAngle - 90),
         roll: this.viewer.camera.roll,
       },
-  });
+    }, options || {});
+
+    this.viewer.camera.flyTo(flyToOptions)
   }
 
   public setNadirViewAngle() {
@@ -244,16 +252,25 @@ export class MapCesiumService {
   public getViewAngle():number{
     return CesiumMath.toDegrees(this.viewer.camera.pitch) + 90;
   }
-// subtract rotation degree from 360° to get the same behavior as in openlayers
-  public setRotation(rotation: number) {
-    this.viewer.camera.flyTo({
+
+  /**
+    *  subtract rotation degree from 360° to get the same behavior as in openlayers
+    *  options of viewer.camera.flyTo`
+    * 
+    * https://github.com/CesiumGS/cesium/blob/99d6fffe20d9cf19f2d70de97777dc00a435bc5e/packages/engine/Source/Scene/Camera.js#L3424
+    * https://github.com/CesiumGS/cesium/blob/99d6fffe20d9cf19f2d70de97777dc00a435bc5e/packages/engine/Source/Scene/Camera.js#L1456
+    */
+  public setRotation(rotation: number, options?: any) {
+    const flyToOptions = Object.assign({
       destination: this.viewer.camera.position,
       orientation: {
-        heading: CesiumMath.toRadians(360-rotation),
+        heading: CesiumMath.toRadians(360 - rotation),
         pitch: this.viewer.camera.pitch,
         roll: this.viewer.camera.roll,
       },
-  });
+    }, options || {});
+
+    this.viewer.camera.flyTo(flyToOptions)
   }
 // subtract rotation degree from 360° to get the same behavior as in openlayers
   public getRotation():number{

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Layer, VectorLayer, CustomLayer, RasterLayer, WmtsLayer, WmsLayer, TGeoExtent, TmsLayertype, WmtsLayertype, WmsLayertype, XyzLayertype, IListMatrixSet, TFiltertypesUncap, TFiltertypes } from '@dlr-eoc/services-layers';
 
 import { ICesiumControls } from './map-cesium.component';
-import { Cartesian3, Cesium3DTileStyle, Cesium3DTileset, CesiumTerrainProvider, Color, Credit, DataSource, EllipsoidTerrainProvider, GeoJsonDataSource, I3SDataProvider, ImageryLayer, Ion, JulianDate, KmlDataSource, Rectangle, TileMapServiceImageryProvider, TimeIntervalCollection, UrlTemplateImageryProvider, WebMapServiceImageryProvider, WebMapTileServiceImageryProvider, WebMercatorTilingScheme, } from '@cesium/engine';
+import { Cartesian3, Cesium3DTileStyle, Cesium3DTileset, CesiumTerrainProvider, Color, Credit, DataSource, EllipsoidTerrainProvider, GeoJsonDataSource, I3SDataProvider, ImageryLayer, Ion, JulianDate, KmlDataSource, Rectangle, TileMapServiceImageryProvider, TimeIntervalCollection, UrlTemplateImageryProvider, WebMapServiceImageryProvider, WebMapTileServiceImageryProvider, WebMercatorTilingScheme, Math as CesiumMath} from '@cesium/engine';
 import { Viewer } from '@cesium/widgets';
 import { IMapCenter } from '@dlr-eoc/services-map-state';
 
@@ -224,38 +224,41 @@ export class MapCesiumService {
   }
 
   // Set initial oblique view, see https://cesium.com/learn/cesiumjs/ref-doc/Camera.html
+  //subtract 90°, to get the same behavior as in openlayers
   public setViewAngle(viewAngle: number) {
-    //const view_angle = 0.2;
-    /*  const height = position.height;
-     const sin_view_angle = Math.sin(view_angle);
-     const dist_square = height*height*((1/(sin_view_angle*sin_view_angle))-1);
-     const dist = Math.sqrt(dist_square);
-     const height_diff = sin_view_angle*dist;
-     //move the camera back in order to view the same scene as in 2D
-     console.log(dist);
-     console.log(height_diff);
-     //this.viewer.camera. moveBackward(dist);
-     //this.viewer.camera. moveDown(height_diff);
-     this.viewer.camera. moveDown(dist);*/
-    this.viewer.camera.lookUp(viewAngle);
-    //this.viewer.camera. moveUp(10000);
-
-
+    this.viewer.camera.flyTo({
+      destination: this.viewer.camera.position,
+      orientation: {
+        heading: this.viewer.camera.heading,
+        pitch: CesiumMath.toRadians(viewAngle-90),
+        roll: this.viewer.camera.roll,
+      },
+  });
   }
 
   public setNadirViewAngle() {
-    const position = this.viewer.camera.position;
-    /*  const heading = MathCesium.toRadians(0);
-     const pitch = MathCesium.toRadians(0);
-     const range = this.viewer.camera.positionCartographic.height;
-     this.viewer.camera.lookAt(center, new HeadingPitchRange(heading, pitch, range)); */
-    this.viewer.camera.flyTo({
-      destination: position,
-      duration: 1
-    });
+    this.setViewAngle(0.01);
   }
 
-
+  //add 90°, to get the same behavior as in openlayers
+  public getViewAngle():number{
+    return CesiumMath.toDegrees(this.viewer.camera.pitch) + 90;
+  }
+// subtract rotation degree from 360° to get the same behavior as in openlayers
+  public setRotation(rotation: number) {
+    this.viewer.camera.flyTo({
+      destination: this.viewer.camera.position,
+      orientation: {
+        heading: CesiumMath.toRadians(360-rotation),
+        pitch: this.viewer.camera.pitch,
+        roll: this.viewer.camera.roll,
+      },
+  });
+  }
+// subtract rotation degree from 360° to get the same behavior as in openlayers
+  public getRotation():number{
+    return 360 - CesiumMath.toDegrees(this.viewer.camera.heading);
+  }
 
   // https://sandcastle.cesium.com/index.html?src=Imagery%2520Layers.html
   // https://sandcastle.cesium.com/index.html?src=Imagery%2520Layers%2520Manipulation.html

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -245,7 +245,7 @@ export class MapCesiumService {
   }
 
   public setNadirViewAngle() {
-    this.setViewAngle(0.01);
+    this.setViewAngle(0);
   }
 
   //add 90°, to get the same behavior as in openlayers

--- a/projects/map-maplibre/src/lib/map-maplibre.component.spec.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.spec.ts
@@ -6,10 +6,11 @@ import { MapStateService } from '@dlr-eoc/services-map-state';
 import { LayersService } from '@dlr-eoc/services-layers';
 import { Map } from 'maplibre-gl';
 import { EocBasemapTile, OsmTileLayer, EocBaseoverlayTile } from '@dlr-eoc/base-layers-raster';
+import { getBearing } from './maplibre.helpers';
 
 
 function addSomeLayers(component: MapMaplibreComponent, mapSvc: MapMaplibreService) {
-  /* 
+  /*
    * Unfortunately, component.subscribeToLayers() does not work in the test, so we have to add the layers manually instead of using layersSvc.
    */
   /**
@@ -29,8 +30,8 @@ function addSomeLayers(component: MapMaplibreComponent, mapSvc: MapMaplibreServi
 }
 
 /**
- *  Unfortunately running tests in watch with edit does not work 
- *  
+ *  Unfortunately running tests in watch with edit does not work
+ *
  * -> Async function did not complete within 5000ms
  */
 describe('MapMaplibreComponent', () => {
@@ -76,6 +77,18 @@ describe('MapMaplibreComponent', () => {
   it('should have a map and the map should be the same as from the mapSvc', () => {
     expect(component.map instanceof Map).toBeTruthy();
     expect(mapSvc.map.getValue()._mapId).toBe(component.map._mapId);
+  });
+
+  it('should set mapstate rotation', () => {
+    //set rotation to 90°
+    component.mapStateSvc.setRotation(90);
+    expect(getBearing(component.map)).toEqual(90);
+  });
+
+  it('should set mapstate view angle', () => {
+    //set view angle to 45°
+    component.mapStateSvc.setViewAngle(45);
+    expect(component.map.getPitch()).toEqual(45);
   });
 
   it('should add/update Layers to the style', () => {

--- a/projects/map-maplibre/src/lib/map-maplibre.component.spec.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.spec.ts
@@ -6,7 +6,7 @@ import { MapStateService } from '@dlr-eoc/services-map-state';
 import { LayersService } from '@dlr-eoc/services-layers';
 import { Map } from 'maplibre-gl';
 import { EocBasemapTile, OsmTileLayer, EocBaseoverlayTile } from '@dlr-eoc/base-layers-raster';
-import { getBearing } from './maplibre.helpers';
+import { getRotation } from './maplibre.helpers';
 
 
 function addSomeLayers(component: MapMaplibreComponent, mapSvc: MapMaplibreService) {
@@ -82,7 +82,7 @@ describe('MapMaplibreComponent', () => {
   it('should set mapstate rotation', () => {
     //set rotation to 90°
     component.mapStateSvc.setRotation(90);
-    expect(getBearing(component.map)).toEqual(90);
+    expect(getRotation(component.map)).toEqual(90);
   });
 
   it('should set mapstate view angle', () => {

--- a/projects/map-maplibre/src/lib/map-maplibre.component.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewChecked, AfterViewInit, Component, ElementRef, Input, NgZone, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Map as glMap, MapLibreEvent, NavigationControl, ScaleControl, StyleSpecification, TypedStyleLayer, GeoJSONSource, Dispatcher, Evented } from 'maplibre-gl';
-import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, UKIS_METADATA, changeOrderOfLayers, setBearing, setPitch, getBearing } from './maplibre.helpers';
+import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, UKIS_METADATA, changeOrderOfLayers, setRotation, setPitch, getRotation } from './maplibre.helpers';
 
 import { MapState, MapStateService } from '@dlr-eoc/services-map-state';
 import { LayersService, TFiltertypes, TFiltertypesUncap, Layer as ukisLayer } from '@dlr-eoc/services-layers';
@@ -242,7 +242,7 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
     const latLng = this.map.getCenter();
     const extent = getExtent(this.map, true);
     const viewAngle = this.map.getPitch();
-    const rotation = getBearing(this.map);
+    const rotation = getRotation(this.map);
 
     const newCenter = { lat: latLng.lat, lon: latLng.lng };
     const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time, viewAngle, rotation);
@@ -286,10 +286,10 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
       } else if (lastAction === 'setState') {
         setZoom(this.map, mapState.zoom, mapState.options.notifier);
         setCenter(this.map, [mapState.center.lon, mapState.center.lat], true);
-        setBearing(this.map, mapState.rotation);
+        setRotation(this.map, mapState.rotation);
         setPitch(this.map, mapState.viewAngle);
       } else if (lastAction === 'setRotation') {
-        setBearing(this.map, mapState.rotation);
+        setRotation(this.map, mapState.rotation);
       } else if (lastAction === 'setAngle') {
         setPitch(this.map, mapState.viewAngle);
       }

--- a/projects/map-maplibre/src/lib/map-maplibre.component.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewChecked, AfterViewInit, Component, ElementRef, Input, NgZone, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Map as glMap, MapLibreEvent, NavigationControl, ScaleControl, StyleSpecification, TypedStyleLayer, GeoJSONSource, Dispatcher, Evented } from 'maplibre-gl';
-import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, UKIS_METADATA, changeOrderOfLayers, setBearing, setPitch } from './maplibre.helpers';
+import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, UKIS_METADATA, changeOrderOfLayers, setBearing, setPitch, getBearing } from './maplibre.helpers';
 
 import { MapState, MapStateService } from '@dlr-eoc/services-map-state';
 import { LayersService, TFiltertypes, TFiltertypesUncap, Layer as ukisLayer } from '@dlr-eoc/services-layers';
@@ -73,6 +73,11 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   ngOnDestroy(): void {
+    const lastMapState = this.mapStateSvc.getMapState().value;
+    lastMapState.options.notifier = 'user';
+    this.mapStateSvc.setMapState(lastMapState);
+     /** clean up all events on destroy */
+     this.subs.forEach(s => s.unsubscribe());
     if (this.map) {
       this.map.off('moveend', this.mapOnMoveend);
       // this.mapDivView.nativeElement.removeEventListener('mouseleave', this.removePopupsOnMouseLeave);
@@ -237,7 +242,7 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
     const latLng = this.map.getCenter();
     const extent = getExtent(this.map, true);
     const viewAngle = this.map.getPitch();
-    const rotation = this.map.getBearing();
+    const rotation = getBearing(this.map);
 
     const newCenter = { lat: latLng.lat, lon: latLng.lng };
     const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time, viewAngle, rotation);

--- a/projects/map-maplibre/src/lib/maplibre.helpers.spec.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.spec.ts
@@ -1,4 +1,4 @@
-import { getOpacity, setOpacity, setVisibility, getAllLayers, getUkisLayerIDs, getLayersAndSources, removeLayerAndSource, changeOrderOfLayers, LayerSourceSpecification, setBearing, setPitch, getBearing } from './maplibre.helpers';
+import { getOpacity, setOpacity, setVisibility, getAllLayers, getUkisLayerIDs, getLayersAndSources, removeLayerAndSource, changeOrderOfLayers, LayerSourceSpecification, setRotation, setPitch, getRotation } from './maplibre.helpers';
 import { StyleSpecification, LayerSpecification, SourceSpecification, Map as glMap } from 'maplibre-gl';
 import { CustomLayer } from '@dlr-eoc/services-layers';
 import { addUkisLayerMetadata } from './maplibre-layers.helpers';
@@ -522,9 +522,9 @@ describe('MaplibreHelpers', () => {
     it('should set/get rotation and view angle', () => {
       const rotation = 45;
       const viewAngle = 45;
-      setBearing(map,rotation);
+      setRotation(map,rotation);
       setPitch(map, viewAngle);
-      expect(getBearing(map)).toBe(rotation);
+      expect(getRotation(map)).toBe(rotation);
       expect(map.getPitch()).toBe(viewAngle);
     });
 

--- a/projects/map-maplibre/src/lib/maplibre.helpers.spec.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.spec.ts
@@ -1,4 +1,4 @@
-import { getOpacity, setOpacity, setVisibility, getAllLayers, getUkisLayerIDs, getLayersAndSources, removeLayerAndSource, changeOrderOfLayers, LayerSourceSpecification } from './maplibre.helpers';
+import { getOpacity, setOpacity, setVisibility, getAllLayers, getUkisLayerIDs, getLayersAndSources, removeLayerAndSource, changeOrderOfLayers, LayerSourceSpecification, setBearing, setPitch, getBearing } from './maplibre.helpers';
 import { StyleSpecification, LayerSpecification, SourceSpecification, Map as glMap } from 'maplibre-gl';
 import { CustomLayer } from '@dlr-eoc/services-layers';
 import { addUkisLayerMetadata } from './maplibre-layers.helpers';
@@ -517,6 +517,15 @@ describe('MaplibreHelpers', () => {
         changeOrderOfLayers(map, changeLayers, ukisMapLayers, 'Layers');
         const newMapLayers = getAllLayers(map, 'Layers').map(l => l.id);
         expect(newMapLayers).toEqual(allChangeLayers);
+    });
+
+    it('should set/get rotation and view angle', () => {
+      const rotation = 45;
+      const viewAngle = 45;
+      setBearing(map,rotation);
+      setPitch(map, viewAngle);
+      expect(getBearing(map)).toBe(rotation);
+      expect(map.getPitch()).toBe(viewAngle);
     });
 
 });

--- a/projects/map-maplibre/src/lib/maplibre.helpers.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.ts
@@ -60,9 +60,14 @@ export function setPitch(map: glMap, pitch: number) {
   //default maxPitch is 60°
   map.setPitch(pitch);
 }
-export function setBearing(map: glMap, rotation: number) {
-  // bearing is defined from -180° to 180°, rotation from 0° to 360°
-  // subtract rotation degree from 360° or change sign to get the same behavior as in openlayers
+/**
+ * @param rotation - Sets the map's rotation (bearing)
+ * bearing is defined from -180° to 180°, rotation from 0° to 360°
+ * This subtracts rotation degrees from 360° or changes the sign to get the same behavior as in OpenLayers.
+ * 
+ * https://github.com/maplibre/maplibre-gl-js/blob/adc7f17061f1aca261c307fcfa2e3e4f2390ef45/src/ui/camera.ts#L505
+ */
+export function setRotation(map: glMap, rotation: number) {
   let bearing = 0;
   if(rotation > 180){
     bearing = 360 - rotation;
@@ -72,9 +77,11 @@ export function setBearing(map: glMap, rotation: number) {
   map.setBearing(bearing);
 }
 
-export function getBearing(map: glMap):number {
-  // bearing is defined from -180° to 180°, rotation from 0° to 360°
-  // subtract bearing degree from 360° or change sign to get the same behavior as in openlayers
+/**
+ * @returns rotation from 0° to 360° (bearing is defined from -180° to 180°) 
+ * subtract bearing degree from 360° or change sign to get the same behavior as in openlayers
+ */
+export function getRotation(map: glMap):number {
   let rotation = 0;
   const bearing = map.getBearing();
   if (bearing > 0){

--- a/projects/map-maplibre/src/lib/maplibre.helpers.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.ts
@@ -52,6 +52,10 @@ export function getZoom(map: glMap, notifier?: 'map' | 'user') {
     return map.getZoom();
 }
 
+/**
+ * @param pitch - The pitch to set, measured in degrees away from the plane of the screen (0-60).
+ * https://github.com/maplibre/maplibre-gl-js/blob/adc7f17061f1aca261c307fcfa2e3e4f2390ef45/src/ui/camera.ts#L616C15-L616C102
+ */
 export function setPitch(map: glMap, pitch: number) {
   //default maxPitch is 60°
   map.setPitch(pitch);

--- a/projects/map-maplibre/src/lib/maplibre.helpers.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.ts
@@ -24,7 +24,7 @@ export function setExtent(map: glMap, extent: TGeoExtent, geographic?: boolean, 
 
 export function getExtent(map: glMap, geographic?: boolean): TGeoExtent {
     const newbounds = map.getBounds();
-    const newExtent = [newbounds.getSouth(), newbounds.getWest(), newbounds.getNorth(), newbounds.getEast()] as TGeoExtent;
+    const newExtent = [newbounds.getWest(), newbounds.getSouth(), newbounds.getEast(), newbounds.getNorth()] as TGeoExtent;
     return newExtent;
 }
 
@@ -55,9 +55,29 @@ export function getZoom(map: glMap, notifier?: 'map' | 'user') {
 export function setPitch(map: glMap, pitch: number) {
   map.setPitch(pitch);
 }
-export function setBearing(map: glMap, bearing: number) {
-  // subtract bearing degree from 360° to get the same behavior as in openlayers
-  map.setBearing(360-bearing);
+export function setBearing(map: glMap, rotation: number) {
+  // bearing is defined from -180° to 180°, rotation from 0° to 360°
+  // subtract rotation degree from 360° or change sign to get the same behavior as in openlayers
+  let bearing = 0;
+  if(rotation > 180){
+    bearing = 360 - rotation;
+  }else{
+    bearing = -rotation;
+  }
+  map.setBearing(bearing);
+}
+
+export function getBearing(map: glMap):number {
+  // bearing is defined from -180° to 180°, rotation from 0° to 360°
+  // subtract bearing degree from 360° or change sign to get the same behavior as in openlayers
+  let rotation = 0;
+  const bearing = map.getBearing();
+  if (bearing > 0){
+    rotation = 360 - bearing;
+  } else if(bearing < 0){
+    rotation = -bearing;
+  }
+  return rotation;
 }
 
 export function setVisibility(map: glMap, layerOrId: string | TypedStyleLayer, visibility: boolean, cb?: () => void) {

--- a/projects/map-maplibre/src/lib/maplibre.helpers.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.ts
@@ -52,6 +52,13 @@ export function getZoom(map: glMap, notifier?: 'map' | 'user') {
     return map.getZoom();
 }
 
+export function setPitch(map: glMap, pitch: number) {
+  map.setPitch(pitch);
+}
+export function setBearing(map: glMap, bearing: number) {
+  // subtract bearing degree from 360° to get the same behavior as in openlayers
+  map.setBearing(360-bearing);
+}
 
 export function setVisibility(map: glMap, layerOrId: string | TypedStyleLayer, visibility: boolean, cb?: () => void) {
     let mllayer;
@@ -273,8 +280,8 @@ export function getLayerChangeOrder(layers: ukisLayer[], mapLayerIds: string[]) 
 
             /**
              * https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#movelayer
-             * The ID of an existing layer to insert the new layer before. 
-             * When viewing the map, layer.id will appear beneath the beforeId layer. 
+             * The ID of an existing layer to insert the new layer before.
+             * When viewing the map, layer.id will appear beneath the beforeId layer.
              * If beforeId is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
              */
             const beforeIndex = index + 1;
@@ -322,10 +329,10 @@ export function changeOrderOfLayer(map: glMap, layerChange: { layerId: string, b
         const beforeMapLayers = getLayersAndSources(map, layerChange.beforeId).layers;
         /* const layerMapLayers = getFirstAndLastLayer(map, layerChange.layerId);
         const beforeMapLayers = getFirstAndLastLayer(map, layerChange.beforeId); */
-        /** 
+        /**
          * if the layer before the one to be moved has several layers, move the layer on beforeMapLayers[0]
          * If there is no layer before, move it to the top.
-         * 
+         *
          * https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#movelayer
          * -  If beforeId is omitted, the layer will be appended to the end of the layers array... -
          */
@@ -361,7 +368,7 @@ export function changeOrderOfLayer(map: glMap, layerChange: { layerId: string, b
                 map.moveLayer(layer.id)
             }
         } else {
-            // layerMapLayers.length === 0 
+            // layerMapLayers.length === 0
             // there is nothing to move
         }
     }

--- a/projects/map-maplibre/src/lib/maplibre.helpers.ts
+++ b/projects/map-maplibre/src/lib/maplibre.helpers.ts
@@ -53,6 +53,7 @@ export function getZoom(map: glMap, notifier?: 'map' | 'user') {
 }
 
 export function setPitch(map: glMap, pitch: number) {
+  //default maxPitch is 60°
   map.setPitch(pitch);
 }
 export function setBearing(map: glMap, rotation: number) {

--- a/projects/map-ol/src/lib/map-ol.component.spec.ts
+++ b/projects/map-ol/src/lib/map-ol.component.spec.ts
@@ -331,6 +331,12 @@ describe('MapOlComponent', () => {
     expect(component.map.getSize()).toEqual(mapSize);
   });
 
+  it('should set mapstate rotation', () => {
+    //set rotation to 90°
+    component.mapStateSvc.setRotation(90);
+    expect(mapSvc.getRotation()).toEqual(90);
+  });
+
   it('should have a three olLayerGroups', () => {
     expect(component.map.getLayers().getLength()).toEqual(3);
     expect(mapSvc.getLayerGroups().length).toEqual(3);
@@ -427,7 +433,7 @@ describe('MapOlComponent', () => {
 
     const layers = [ukisOlLayerGroup, testVector, ukisOlLayerGroup2];
 
-    // trigger update of layers 
+    // trigger update of layers
     component['addUpdateLayers'](layers, 'layers', ['baselayers']);
 
     const osmFromMap = mapSvc.getLayerByKey({ key: 'id', value: osmLayer.id });

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -468,6 +468,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       } else if (lastAction === 'setState') {
         this.mapSvc.setZoom(mapState.zoom);
         this.mapSvc.setCenter([mapState.center.lon, mapState.center.lat], true);
+        this.mapSvc.setRotation(mapState.rotation);
       } else if (lastAction === 'setRotation') {
         this.mapSvc.setRotation(mapState.rotation);
       }

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -158,7 +158,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
         if (!this.initialMapStateSet) {
           /**
            * If container size and map size are equal (map size 'stable')
-           * Get last state from mapStateSvc and set it, so a User can set the initial MapState in a component on ngOnInit 
+           * Get last state from mapStateSvc and set it, so a User can set the initial MapState in a component on ngOnInit
            * Update map size before so view.fit can calculate correct center
            */
           const oldMapState = this.mapStateSvc.getMapState().getValue();
@@ -468,6 +468,8 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       } else if (lastAction === 'setState') {
         this.mapSvc.setZoom(mapState.zoom);
         this.mapSvc.setCenter([mapState.center.lon, mapState.center.lat], true);
+      } else if (lastAction === 'setRotation') {
+        this.mapSvc.setRotation(mapState.rotation);
       }
     }
     /* else if (mapState.options.notifier === 'map') {
@@ -489,9 +491,10 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       const zoom = this.mapSvc.getZoom();
       const center = this.mapSvc.getCenter(true);
       const extent = this.mapSvc.getCurrentExtent(true);
+      const rotation = this.mapSvc.getRotation();
 
       const newCenter = { lat: parseFloat(center[1]), lon: parseFloat(center[0]) };
-      const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time);
+      const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time, oldMapState.viewAngle, rotation);
       this.mapStateSvc.setMapState(ms);
     };
     this.map.on('moveend', this.mapOnMoveend);

--- a/projects/map-ol/src/lib/map-ol.service.spec.ts
+++ b/projects/map-ol/src/lib/map-ol.service.spec.ts
@@ -1570,6 +1570,15 @@ describe('MapOlService State', () => {
     expect(service.getCenter(true)[1]).toBeCloseTo(center[1], 1);
   });
 
+  it('should set/get rotation', () => {
+    const service: MapOlService = TestBed.inject(MapOlService);
+    service.createMap(mapTarget.container);
+    const rotation = 45;
+    service.setRotation(rotation);
+    expect(service.getRotation()).toBe(45);
+    // Rounding errors 47.99999999999997 to equal 48
+  });
+
   it('should have a default zoom of 0', () => {
     const service: MapOlService = TestBed.inject(MapOlService);
     service.createMap(mapTarget.container);

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -2345,8 +2345,12 @@ export class MapOlService {
     return (transfomExtent as TGeoExtent);
   }
 
-  /** USED in map-ol.component */
-  /** ol.Coordinate xy */
+  /** 
+   * USED in map-ol.component
+   * ol.Coordinate xy
+   * 
+   * https://github.com/openlayers/openlayers/blob/0b6305ac8a7665312ba30a89d87e08af7c69ddd4/src/ol/View.js#L1707 
+   */
   public setCenter(center: number[], geographic?: boolean): number[] {
     const projection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
     const transfomCenter = transform(center, projection, this.getProjection().getCode());
@@ -2395,7 +2399,12 @@ export class MapOlService {
     return (transfomExtent as TGeoExtent);
   }
 
-   /** USED in map-ol.component */
+   /** 
+    * USED in map-ol.component
+    * 
+    * https://github.com/openlayers/openlayers/blob/0b6305ac8a7665312ba30a89d87e08af7c69ddd4/src/ol/View.js#L291
+    * https://github.com/openlayers/openlayers/blob/0b6305ac8a7665312ba30a89d87e08af7c69ddd4/src/ol/View.js#L1707
+    */
    public setRotation(rotation: number) {
     const view = this.map.getView();
     // convert rotation vom deg to rad

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1410,7 +1410,7 @@ export class MapOlService {
     if (l instanceof StackedLayer) {
       const layers = l.layers.map(ml => {
         // Set visibility and opacity from the StackedLayer as start for all the layers
-        // they will be updated later by layerOrGroupSetVisible and layerOrGroupSetOpacity in map-ol component 
+        // they will be updated later by layerOrGroupSetVisible and layerOrGroupSetOpacity in map-ol component
         ml.visible = l.visible;
         ml.opacity = l.opacity;
         /** popups are get from the olLayer later so add them */
@@ -1544,23 +1544,23 @@ export class MapOlService {
    *  - check for popup.asObservable and create map
    *  - pixel coordinate in layer extent
    *  - layer has popup
-   * 
+   *
    *  - filterLayerNoPopup
    *  - layer has pixel data
    *  - pixel data alpha value > 0
    *  - layer is raster
-   * 
+   *
    *  - filterLayerNoPopup
    *  - pixel coordinate in layer extent
    *  - layer is vector
    *  - layer has features at pixel
-   * 
+   *
    * returns top visible layer - so no popups are shown for layers beneath if layer.opacity > 0 https://github.com/dlr-eoc/ukis-frontend-libraries/issues/94#issuecomment-916759628
    *  2. check top layer event (click or move)
    *  3. set cursor for Layers with a color value or feature
    *     if no layer has been hit and the map popup.asObservable has items, then publish a null event for them
    *  4. differentiate between raster and vector
-   * 
+   *
    *  5. limit properties if popup property is: Array<string> | popup | popup[] -> popup?.filterkeys
    *  6. overwrite properties if popup property is: popup | popup[]
    *  7. check for popupFunction, asyncPopup, dynamicPopup and asObservable
@@ -1670,8 +1670,8 @@ export class MapOlService {
     }
   }
 
-  /** 
-   * Check for popup.asObservable to publish null properties if layer is not hit. 
+  /**
+   * Check for popup.asObservable to publish null properties if layer is not hit.
    */
   private checkForPopupAsObservable(layer: olLayer<olSource, LayerRenderer<any>>, layerVisible: boolean, layerOpacity: number, layerPopup: Layer['popup'], layerPopupsAsObservable: Map<string, olLayer<olSource, LayerRenderer<any>>>) {
     if (layerVisible && layerOpacity !== 0 && layerPopup) {
@@ -1687,8 +1687,8 @@ export class MapOlService {
     }
   }
 
-  /** 
-   * Publish null properties for popup.asObservable if layer is not hit. 
+  /**
+   * Publish null properties for popup.asObservable if layer is not hit.
    */
   private publishNullPropertiesAsObservable(layerPopupsAsObservable: Map<string, olLayer<olSource, LayerRenderer<any>>>, event: olMapBrowserEvent<PointerEvent>) {
     if (layerPopupsAsObservable.size) {
@@ -1833,7 +1833,7 @@ export class MapOlService {
   public vectorOnEvent(evt: olMapBrowserEvent<PointerEvent>, layer: olLayer<any>, feature: olFeature | olRenderFeature) {
     if (layer && feature) {
       const popup: Layer['popup'] = layer.get(POPUP_KEY);
-      /** 
+      /**
        * properties of olFeature.
        */
       let properties: any = {};
@@ -2393,6 +2393,20 @@ export class MapOlService {
     const extent = this.map.getView().calculateExtent();
     const transfomExtent = transformExtent(extent, this.getProjection().getCode(), projection);
     return (transfomExtent as TGeoExtent);
+  }
+
+   /** USED in map-ol.component */
+   public setRotation(rotation: number) {
+    const view = this.map.getView();
+    // convert rotation vom deg to rad
+    rotation = rotation * (Math.PI/180);
+    view.setRotation(rotation);
+  }
+
+  /** USED in map-ol.component */
+  public getRotation(): number {
+    // convert rotation vom rad to deg
+    return this.map.getView().getRotation() * (180/Math.PI);
   }
 
   /** USED in map-ol.component */

--- a/projects/services-map-state/README.md
+++ b/projects/services-map-state/README.md
@@ -1,6 +1,6 @@
 # @dlr-eoc/services-map-state
 
-The `MapStateService` should be an interface to handle `zoom`, `center`, `extent` and `time` of maps.
+The `MapStateService` should be an interface to handle `zoom`, `center`, `extent`, `view angle`, `rotation` and `time` of maps.
 The idea is similar to `@dlr-eoc/services-layers`.
 ### how to use this in a ukis-angular (@dlr-eoc/core-ui) project
 
@@ -26,6 +26,8 @@ For examples see:
 
 This module is used by components like:
 - @dlr-eoc/map-ol
+- @dlr-eoc/map-cesium
+- @dlr-eoc/map-maplibre
 - @dlr-eoc/map-tools
 - @dlr-eoc/layer-control
 - ...
@@ -35,6 +37,8 @@ It implements a basic 'state' for the map like:
 - center
 - options
 - extent
+- view angle (for 3D maps)
+- rotation
 - time
 
 for more details [see map-state](../services-map-state/src/lib/types/map-state.ts)

--- a/projects/services-map-state/src/lib/map-state.service.spec.ts
+++ b/projects/services-map-state/src/lib/map-state.service.spec.ts
@@ -26,6 +26,7 @@ describe('MapStateService', () => {
     const stateTime = new Date().toISOString(); // this is passed on new MapState()
     const state = new MapState(4, { lat: 48, lon: 11 });
     state.time = stateTime;
+    state.rotation = 20;
 
 
     service.setMapState(state);
@@ -34,6 +35,8 @@ describe('MapStateService', () => {
       expect(sta.center.lon).toEqual(11);
       expect(sta.zoom).toEqual(4);
       expect(sta.time).toEqual(stateTime);
+      expect(sta.rotation).toEqual(20);
+      expect(sta.viewAngle).toEqual(0);
     });
   }));
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -59,6 +59,18 @@ export class MapStateService {
     this.setMapState(state);
   }
 
+  public setViewAngle(angel: number) {
+    const state = this.getMapState().getValue();
+    state.viewAngle = angel;
+    this.setMapState(state);
+  }
+
+  public setRotation(rotation: number) {
+    const state = this.getMapState().getValue();
+    state.rotation = rotation;
+    this.setMapState(state);
+  }
+
 
   public getLastAction() {
     return this.lastAction;

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -24,11 +24,11 @@ export class MapStateService {
     }
     this.lastAction.next('setState');
     if (state instanceof MapState) {
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, state.viewAngle, state.rotation);
       this.mapState.next(newState);
     } else {
       const stateOptions: IMapStateOptions = { ...{ notifier: 'user' }, ...state.options };
-      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.time);
+      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.time, state.viewAngle, state.rotation);
       this.mapState.next(newState);
     }
   }
@@ -44,7 +44,7 @@ export class MapStateService {
     this.lastAction.next('setExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, extent, state.time);
+    const newState = new MapState(state.zoom, state.center, state.options, extent, state.time, state.viewAngle, state.rotation);
     this.mapState.next(newState);
   }
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -10,7 +10,7 @@ const initialState = new MapState(0, { lat: 0, lon: 0 });
 })
 export class MapStateService {
   private mapState = new BehaviorSubject(initialState)
-  private lastAction = new BehaviorSubject<'setExtent' | 'setState'>(null);
+  private lastAction = new BehaviorSubject<'setExtent' | 'setState' | 'setRotation' | 'setAngle'>(null);
   constructor() {
   }
 
@@ -59,16 +59,26 @@ export class MapStateService {
     this.setMapState(state);
   }
 
-  public setViewAngle(angel: number) {
+  public setViewAngle(angle: number, notifier: IMapState['options']['notifier'] = 'user') {
+    if (!angle) {
+      return;
+    }
+    this.lastAction.next('setAngle');
     const state = this.getMapState().getValue();
-    state.viewAngle = angel;
-    this.setMapState(state);
+    state.options.notifier = notifier;
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, angle, state.rotation);
+    this.mapState.next(newState);
   }
 
-  public setRotation(rotation: number) {
+  public setRotation(rotation: number, notifier: IMapState['options']['notifier'] = 'user') {
+    if (!rotation) {
+      return;
+    }
+    this.lastAction.next('setRotation');
     const state = this.getMapState().getValue();
-    state.rotation = rotation;
-    this.setMapState(state);
+    state.options.notifier = notifier;
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, state.viewAngle, rotation);
+    this.mapState.next(newState);
   }
 
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -10,7 +10,7 @@ const initialState = new MapState(0, { lat: 0, lon: 0 });
 })
 export class MapStateService {
   private mapState = new BehaviorSubject(initialState)
-  private lastAction = new BehaviorSubject<'setExtent' | 'setState' | 'setRotation' | 'setAngle'>(null);
+  private lastAction = new BehaviorSubject<'setExtent' | 'setState' | 'setRotation' | 'setAngle' | 'setTime'>(null);
   constructor() {
   }
 
@@ -38,7 +38,7 @@ export class MapStateService {
   }
 
   public setExtent(extent: TGeoExtent, notifier: IMapState['options']['notifier'] = 'user') {
-    if (!extent) {
+    if (!Array.isArray(extent)) {
       return;
     }
     this.lastAction.next('setExtent');
@@ -48,8 +48,10 @@ export class MapStateService {
     this.mapState.next(newState);
   }
 
-  public setTime(time: Date | string) {
+  public setTime(time: Date | string, notifier: IMapState['options']['notifier'] = 'user') {
+    this.lastAction.next('setTime');
     const state = this.getMapState().getValue();
+    state.options.notifier = notifier;
 
     if (time instanceof Date) {
       state.time = time.toISOString();
@@ -59,8 +61,16 @@ export class MapStateService {
     this.setMapState(state);
   }
 
+  /**
+   * @param angle
+   * This is not available for OpenLayers (only rotation)
+   * 
+   * For Maplibre the default is from 0 to 60. Can be increasd with setMaxPitch (0-85). Values greater than 60 degrees are experimental and may result in rendering issues.
+   * 
+   * For Cesium values greater than 90, is like looking from the ground up to the sky. Values greater than 180 also rotate the globe.
+   */
   public setViewAngle(angle: number, notifier: IMapState['options']['notifier'] = 'user') {
-    if (!angle) {
+    if (isNaN(angle)) {
       return;
     }
     this.lastAction.next('setAngle');
@@ -71,7 +81,7 @@ export class MapStateService {
   }
 
   public setRotation(rotation: number, notifier: IMapState['options']['notifier'] = 'user') {
-    if (!rotation) {
+    if (isNaN(rotation)) {
       return;
     }
     this.lastAction.next('setRotation');

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -16,6 +16,10 @@ export interface IMapState {
   extent?: TGeoExtent;
   /** iso 8601 Datestring */
   time?: string;
+  /** from nadir in degrees */
+  viewAngle?: number;
+  /** from north in degrees */
+  rotation?: number;
 }
 
 /**
@@ -33,8 +37,12 @@ export class MapState implements IMapState {
   extent: TGeoExtent;
   /** iso 8601 Datestring */
   time: string;
+  /** from nadir in degrees */
+  viewAngle: number;
+  /** from north in degrees */
+  rotation: number;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], time: string = new Date().toISOString()) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0) {
     const defaultOptions = {
       maxzoom: 0,
       minzoom: 0,
@@ -44,6 +52,8 @@ export class MapState implements IMapState {
     this.center = center;
     this.extent = extent;
     this.time = time;
+    this.viewAngle = viewAngle;
+    this.rotation = rotation;
     this.options = Object.assign(defaultOptions, options);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For 3D applications it would be useful to add view rotation and view angle to the mapState. This would enable us to set initial values and change them according to user input.
Issue Number: #216 


## What is the new behavior?
The mapState now contains the values rotation and viewAngle. To use this functionality, map-ol, map-cesium and map-maplibre were connected to the new mapState values. In demo-maps some examples were added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
- [@dlr-eoc/services-map-state](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/main/projects/services-map-state)
- [@dlr-eoc/map-ol](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/main/projects/map-ol)
- [@dlr-eoc/map-cesium](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/main/projects/map-cesium)
- [@dlr-eoc/map-maplibre](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/main/projects/map-maplibre)
- [@dlr-eoc/demo-maps](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/main/projects/demo-maps)
