### PR TITLE
feat: allow hide popup if functions return false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 * **@dlr-eoc/layer-control:**
   - Fix direction of `@cds` icon
 
+### Features
+* **@dlr-eoc/services-layers:**
+  - Allow return `false` for `popup.popupFunction` and `popup.asyncPopup`;
+* **@dlr-eoc/map-ol:**
+  - Do not add a popup if `popup.popupFunction` or `popup.asyncPopup` return `false`;
+
 ### Documentation
 - Update `TUTORIALS.md`
 - Minor changes in some libraries's `README.md`

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -51,13 +51,15 @@ export interface popup {
   /** 
    * function to create the popup content.
    * Return an HTML string or an object from which an HTML string is generated.
+   * If false is returned, only the function is executed, but no popup is added.
    */
-  popupFunction?: (popupParams: IPopupParams) => string | IAnyObject;
+  popupFunction?: (popupParams: IPopupParams) => string | IAnyObject | false;
   /** 
    * async function to create the popup content.
    * Pass an HTML string, or an object from which an HTML string is generated, to the callback..
+   * If no callback is used, only the function is executed, but no popup is added.
    */
-  asyncPopup?: (popupParams: IPopupParams, cb: (content: string | IAnyObject) => void) => void;
+  asyncPopup?: (popupParams: IPopupParams, cb: (content: string | IAnyObject | false) => void) => void;
   /** create popup using angular component */
   dynamicPopup?: {
     component: Type<any>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the new behavior?

- Allow return `false` for `popup.popupFunction` and `popup.asyncPopup` in map-ol service, to not show a popup.

This can be useful to listen on layer `click` or `move` to execute a function that does something else with the layer, but does not display a popup.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?

* **@dlr-eoc/services-layers:**
* **@dlr-eoc/map-ol:**
