### PR TITLE
Integrate projections in MapState

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       # This builds the project for projects/demo-maps and outputs the result to the 'dist' folder.
       # https://github.com/angular/angular-cli/issues/9016#issuecomment-526825531

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -172,7 +172,7 @@ jobs:
           for dir in ./dist/*/;
           do
               dir=${dir%*/}
-              npm publish "$dir" --access public
+              npm publish "$dir" --access public --tag "latest"
           done
         env:
           AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -288,7 +288,7 @@ jobs:
           for dir in ./dist/*/
           do
               dir=${dir%*/}
-              npm publish "$dir" --access public
+              npm publish "$dir" --access public --tag "next"
           done
         env:
           AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -146,6 +146,9 @@ jobs:
   publish-gpr_pr:
     needs: [checkHeadBranch_pr, checkTitelTag_pr, checkTagOnNpm_pr, build_pr, checkLabel_pr, gh-release_pr]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Download dist result from job build
@@ -169,7 +172,7 @@ jobs:
           for dir in ./dist/*/;
           do
               dir=${dir%*/}
-              npm publish "$dir" --access public --tag "latest" --provenance
+              npm publish "$dir" --access public
           done
         env:
           AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -258,6 +261,9 @@ jobs:
   publish-gpr_push:
     needs: [gh-release_push, build_push]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Download dist result from job build
@@ -282,7 +288,7 @@ jobs:
           for dir in ./dist/*/
           do
               dir=${dir%*/}
-              npm publish "$dir" --access public --tag "next" --provenance
+              npm publish "$dir" --access public
           done
         env:
           AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -164,9 +164,21 @@ jobs:
       - run: npm ci
       ### update npm to >8.19 for publish https://github.com/npm/cli/issues/2453 https://github.com/npm/cli/issues/3573
       - run: npm i -g npm@latest  # Latest npm for trusted publishing
-      - run: rm -f .npmrc
+      - name: Check if .npmrc is there and delete file if it exists
+        id: check_and_delete_npmrc
+        run: |
+          FILE_PATH=".npmrc"
+          if [ -f "$FILE_PATH" ]; then
+            echo "File exists: $FILE_PATH"
+            rm -f "$FILE_PATH"
+            echo "File deleted."
+          else
+            echo "File does not exist: $FILE_PATH"
+          fi
       ### for each module in dist update package.json and create .npmrc
       - run: node scripts/library/index.js --update-package=https://npm.pkg.github.com/
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       ### for each module in dist publish frontend-libraries to registry
       - run: |
           for dir in ./dist/*/;
@@ -175,7 +187,7 @@ jobs:
               npm publish "$dir" --access public --tag "latest"
           done
         env:
-          AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   publish-npm_pr:
     needs: [checkHeadBranch_pr, checkTitelTag_pr, checkTagOnNpm_pr, build_pr, checkLabel_pr, gh-release_pr]
@@ -279,9 +291,21 @@ jobs:
       - run: npm ci
       ### update npm to >8.19 for publish https://github.com/npm/cli/issues/2453 https://github.com/npm/cli/issues/3573
       - run: npm i -g npm@latest  # Latest npm for trusted publishing
-      - run: rm -f .npmrc
+      - name: Check if .npmrc is there and delete file if it exists
+        id: check_and_delete_npmrc
+        run: |
+          FILE_PATH=".npmrc"
+          if [ -f "$FILE_PATH" ]; then
+            echo "File exists: $FILE_PATH"
+            rm -f "$FILE_PATH"
+            echo "File deleted."
+          else
+            echo "File does not exist: $FILE_PATH"
+          fi
       ### for each module in dist update package.json and create .npmrc
       - run: node scripts/library/index.js --update-package=https://npm.pkg.github.com/
+        env:
+            NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       ### for each module in dist publish frontend-libraries to registry
       - run: |
           # Pre-release: use tag next
@@ -291,7 +315,7 @@ jobs:
               npm publish "$dir" --access public --tag "next"
           done
         env:
-          AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
   
   publish-npm_push:
     needs: [gh-release_push, build_push]

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -36,10 +36,10 @@ jobs:
     needs: checkHeadBranch_pr
     if: github.event_name == 'pull_request'  # Only for PRs
     steps:
-      # - uses: actions/checkout@v4
+      # - uses: actions/checkout@v6
       # needs uses: actions/checkout@ if script/module is required
       - name: checkTitelTag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: get-tag
         with:
           result-encoding: string
@@ -74,14 +74,14 @@ jobs:
     needs: [checkHeadBranch_pr, checkTitelTag_pr]
     if: github.event_name == 'pull_request' && needs.checkTitelTag_pr.outputs.VERSION_TAG != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: checkout tag
         run: |
           git fetch --all --tags
           git checkout ${{ needs.checkTitelTag_pr.outputs.VERSION_TAG }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - run: rm -f .npmrc
       - uses: ./.github/actions/check-tag-on-npm
         with:
@@ -93,14 +93,14 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.checkTitelTag_pr.outputs.VERSION_TAG != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: checkout tag
         run: |
           git fetch --all --tags
           git checkout ${{ needs.checkTitelTag_pr.outputs.VERSION_TAG }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: build
         run: |
            npm ci
@@ -117,7 +117,7 @@ jobs:
     needs: [build_pr]
     steps:
       - name: checkLabel
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if(context.payload.pull_request.labels){
@@ -147,15 +147,15 @@ jobs:
     needs: [checkHeadBranch_pr, checkTitelTag_pr, checkTagOnNpm_pr, build_pr, checkLabel_pr, gh-release_pr]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download dist result from job build
         uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: dist
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://npm.pkg.github.com/
           scope: "@dlr-eoc"
       - run: npm ci
@@ -178,15 +178,15 @@ jobs:
     needs: [checkHeadBranch_pr, checkTitelTag_pr, checkTagOnNpm_pr, build_pr, checkLabel_pr, gh-release_pr]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download dist result from job build
         uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: dist
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           scope: "@dlr-eoc"
       - run: npm ci
@@ -212,10 +212,10 @@ jobs:
     if: github.event_name == 'push'
     steps:
       # check out before using actions reference from the same repository!
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - run: rm -f .npmrc
       - uses: ./.github/actions/check-tag-on-npm
         with:
@@ -226,10 +226,10 @@ jobs:
     needs: [checkTagOnNpm_push]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - uses: ./.github/actions/test
       - name: build
         run: |
@@ -259,15 +259,15 @@ jobs:
     needs: [gh-release_push, build_push]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download dist result from job build
         uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: dist
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://npm.pkg.github.com/
           scope: "@dlr-eoc"
       - run: npm ci
@@ -291,15 +291,15 @@ jobs:
     needs: [gh-release_push, build_push]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download dist result from job build
         uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: dist
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           scope: "@dlr-eoc"
       - run: npm ci

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,9 +16,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - uses: ./.github/actions/test
       - uses: ./.github/actions/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * **@dlr-eoc/ngx-ukis-ui-clarity:**
 - New UKIS library for ui-clarity related things was added.
 - It includes all components of `@dlr-eoc/layer-control`, `@dlr-eoc/map-tools`, `@dlr-eoc/user-info` [Issue #267](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/267).
+- Adjust `LayerentryComponent` and `LayerentryGroupComponent` to use `nativeBbox` of types `services-layers`.
 
 * **@dlr-eoc/ngx-ukis-utilities:**
 - New UKIS library for angular utilities was added.
@@ -66,6 +67,7 @@
 
 * **@dlr-eoc/map-ol:**
 - Remove dependency on @cds/core [Issue #267](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/267).
+- Use `nativeBbox` of types `services-layers` to create `olLayerOptions.extent` for layers. Use it also in `CustomLayer` to create `olLayerOptions.extent` and for olLayerGroups. 
 
 * **@dlr-eoc/services-layers:**
 - Add `properties` attribute to Layer type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 * **@dlr-eoc/services-layers:**
 - Add `properties` attribute to Layer type
+- Add `nativeBbox?: {epsg: string, bbox: TGeoExtent}` to `Layer` and `LayerGroup`. This can be helpful when zooming to the extent of a projected layer.
 
 * **@dlr-eoc/services-map-state:**
 - Export constants for `WebMercator`, `WGS84` and interface `IProjDef` and some projections `EPSG_3031_Def`, `EPSG_3995_Def`, `EPSG_3857_Def` and `EPSG_4326_Def`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 * **@dlr-eoc/services-map-state:**
 - Export constants for `WebMercator`, `WGS84` and interface `IProjDef` and some projections `EPSG_3031_Def`, `EPSG_3995_Def`, `EPSG_3857_Def` and `EPSG_4326_Def`.
-- Add functionality to `setProjection` and `nativeExtent` (not WGS84) in `MapStateService` [Issue #204](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/204).
+- Add functionality to `setProjection`, `registerProjection` and set `nativeExtent` (not WGS84) in `MapStateService`. Now this can be used instead of the functions in `MapOlService` [Issue #204](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/204).
 
 # [15.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v15.0.0) (2024-12-31) (angular update, @clr and @cds update, layer-control, map-ol)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 * **@dlr-eoc/services-map-state:**
 - Export constants for `WebMercator`, `WGS84` and interface `IProjDef` and some projections `EPSG_3031_Def`, `EPSG_3995_Def`, `EPSG_3857_Def` and `EPSG_4326_Def`.
+- Add functionality to `setProjection` and `nativeExtent` (not WGS84) in `MapStateService` [Issue #204](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/204).
 
 # [15.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v15.0.0) (2024-12-31) (angular update, @clr and @cds update, layer-control, map-ol)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 * **@dlr-eoc/services-map-state:**
 - Export constants for `WebMercator`, `WGS84` and interface `IProjDef` and some projections `EPSG_3031_Def`, `EPSG_3995_Def`, `EPSG_3857_Def` and `EPSG_4326_Def`.
+- Add projection object to `MapState` [Issue #204](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/204)
 - Add functionality to `setProjection`, `registerProjection` and set `nativeExtent` (not WGS84) in `MapStateService`. Now this can be used instead of the functions in `MapOlService` [Issue #204](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/204).
 
 # [15.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v15.0.0) (2024-12-31) (angular update, @clr and @cds update, layer-control, map-ol)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 * **@dlr-eoc/map-tools:**
   - use `clr-number-input-container` instead of `clr-input-container` for input of `type="number"`.
 
+* **@dlr-eoc/map-ol:**
+  - Use 8 stops for all OpenLayers `transformExtent()` functions to sample more points along the edges for better results. Should have only minimal perf hit. This corrects some calculations of extents from WGS84 to other projections. For example, in `setProjection`, new extents for layers are more precise and layers are no longer clipped.
 
 ### Features
 - Remove `standalone: true` Angular directives, components and pipes are now standalone by default since version 19.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 * **@dlr-eoc/services-layers:**
 - Add `properties` attribute to Layer type
 
+* **@dlr-eoc/services-map-state:**
+- Export constants for `WebMercator`, `WGS84` and interface `IProjDef` and some projections `EPSG_3031_Def`, `EPSG_3995_Def`, `EPSG_3857_Def` and `EPSG_4326_Def`.
+
 # [15.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v15.0.0) (2024-12-31) (angular update, @clr and @cds update, layer-control, map-ol)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
  - Input `mapStateSvc` on `<ukis-projection-switch>` was renamed to `mapState`! Input `fitViewToNewExtent` is now triggered by `mapSvc.setProjection`.
  
  - MousePositionComponent need now Inputs `<ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc">`
+
+* **@dlr-eoc/map-ol:**
+ - Params of `setProjection(projection: olProjection | string)` changed to `setProjection(projection: IProjDef | string, options?: IProjOptions)` in `MapOlService`. This allows the registration of proj4 definitions for projections from `IProjDef`. The options `IProjOptions` allow to zomm to a bbox on setProjection or zomm to the ProjectionExtent.
+
 * **@dlr-eoc/map-cesium:**
  - `MapCesiumService.getCurrentExtent()` param `geographic?: boolean` is removed because it was not used.
 
@@ -46,8 +50,6 @@
 * **@dlr-eoc/map-tools:**
   - use `clr-number-input-container` instead of `clr-input-container` for input of `type="number"`.
 
-* **@dlr-eoc/map-ol:**
-  - Fix `setProjection` zoom to old bbox. Add new param `fitToProjectionExtent` on `setProjection` to zoom to new projection extent.
 
 ### Features
 - Remove `standalone: true` Angular directives, components and pipes are now standalone by default since version 19.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
  - MousePositionComponent need now Inputs `<ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc">`
 
 * **@dlr-eoc/map-ol:**
- - Params of `setProjection(projection: olProjection | string)` changed to `setProjection(projection: IProjDef | string, options?: IProjOptions)` in `MapOlService`. This allows the registration of proj4 definitions for projections from `IProjDef`. The options `IProjOptions` allow to zomm to a bbox on setProjection or zomm to the ProjectionExtent.
+ - Params of `setProjection(projection: olProjection | string)` changed to `setProjection(projection: IProjDef | string, options?: IProjFitOptions)` in `MapOlService`. This allows the registration of proj4 definitions for projections from `IProjDef`. The options `IProjFitOptions` allow to zomm to a bbox on setProjection or zomm to the ProjectionExtent.
 
 * **@dlr-eoc/map-cesium:**
  - `MapCesiumService.getCurrentExtent()` param `geographic?: boolean` is removed because it was not used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
  - Removed `pipes` and moved it to new library `@dlr-eoc/ngx-ukis-utilities` [Issue #267](https://github.com/dlr-eoc/ukis-frontend-libraries/issues/267).
 
  * **@dlr-eoc/ngx-ukis-ui-clarity:**
- - Input `mapStateSvc` was removed from `<ukis-projection-switch>`! Input `fitViewToNewExtent` is now triggered by `mapSvc.setProjection`.
-
+ - Input `mapStateSvc` on `<ukis-projection-switch>` was renamed to `mapState`! Input `fitViewToNewExtent` is now triggered by `mapSvc.setProjection`.
+ 
+ - MousePositionComponent need now Inputs `<ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc">`
 ### Bug Fixes
 * **@dlr-eoc/map-maplibre:**
 - Fix type errors on `setData` and test for string if kml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
  - Input `mapStateSvc` on `<ukis-projection-switch>` was renamed to `mapState`! Input `fitViewToNewExtent` is now triggered by `mapSvc.setProjection`.
  
  - MousePositionComponent need now Inputs `<ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc">`
+* **@dlr-eoc/map-cesium:**
+ - `MapCesiumService.getCurrentExtent()` param `geographic?: boolean` is removed because it was not used.
+
 ### Bug Fixes
 * **@dlr-eoc/map-maplibre:**
 - Fix type errors on `setData` and test for string if kml.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="projects/ngx-ukis-ui-clarity/schematics/ng-add/files/src/assets/icons/icon-72x72.png" alt="UKIS Logo"> Frontend Libraries for DLR UKIS (Map) Applications
 ========================
 
-![CI](https://github.com/dlr-eoc/ukis-frontend-libraries/workflows/Test%20and%20Build%20CI/badge.svg)
+![CI](https://github.com/dlr-eoc/ukis-frontend-libraries/actions/workflows/package-release.yml/badge.svg)
 ![Npm Package](https://github.com/dlr-eoc/ukis-frontend-libraries/workflows/Package%20Main%20Release/badge.svg) ![Package Version](https://img.shields.io/github/v/tag/dlr-eoc/ukis-frontend-libraries?sort=semver)
 [![DOI](https://zenodo.org/badge/246639318.svg)](https://zenodo.org/badge/latestdoi/246639318)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ukis-frontend-libraries",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -22604,10 +22604,10 @@
     },
     "projects/base-layers-raster": {
       "name": "@dlr-eoc/base-layers-raster",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22618,10 +22618,10 @@
     },
     "projects/cookie-alert": {
       "name": "@dlr-eoc/cookie-alert",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-util-store": "16.0.0-next.5",
+        "@dlr-eoc/services-util-store": "16.0.0-next.6",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22634,13 +22634,13 @@
       }
     },
     "projects/demo-auth": {
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/cookie-alert": "16.0.0-next.5",
-        "@dlr-eoc/map-ol": "16.0.0-next.5",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.5"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/cookie-alert": "16.0.0-next.6",
+        "@dlr-eoc/map-ol": "16.0.0-next.6",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22657,18 +22657,18 @@
       }
     },
     "projects/demo-maps": {
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/map-cesium": "16.0.0-next.5",
-        "@dlr-eoc/map-maplibre": "16.0.0-next.5",
-        "@dlr-eoc/map-ol": "16.0.0-next.5",
-        "@dlr-eoc/map-three": "16.0.0-next.5",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.5",
-        "@dlr-eoc/services-ogc": "16.0.0-next.5",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5",
-        "@dlr-eoc/utils-maps": "16.0.0-next.5"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/map-cesium": "16.0.0-next.6",
+        "@dlr-eoc/map-maplibre": "16.0.0-next.6",
+        "@dlr-eoc/map-ol": "16.0.0-next.6",
+        "@dlr-eoc/map-three": "16.0.0-next.6",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
+        "@dlr-eoc/services-ogc": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6",
+        "@dlr-eoc/utils-maps": "16.0.0-next.6"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22688,18 +22688,18 @@
     },
     "projects/map-cesium": {
       "name": "@dlr-eoc/map-cesium",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/engine": "^22.3.0",
         "@cesium/widgets": "^14.3.0",
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22709,19 +22709,19 @@
     },
     "projects/map-maplibre": {
       "name": "@dlr-eoc/map-maplibre",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
-        "@dlr-eoc/utilities": "16.0.0-next.5",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/utilities": "16.0.0-next.6",
         "@mapbox/togeojson": "0.16.2",
         "maplibre-gl": "^5.5.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22731,12 +22731,12 @@
     },
     "projects/map-ol": {
       "name": "@dlr-eoc/map-ol",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
-        "@dlr-eoc/utils-maps": "16.0.0-next.5",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/utils-maps": "16.0.0-next.6",
         "ol": "^v10.8.0",
         "ol-mapbox-style": "^13.2.1",
         "proj4": "^2.17.0",
@@ -22744,8 +22744,8 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22756,13 +22756,13 @@
     },
     "projects/map-three": {
       "name": "@dlr-eoc/map-three",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/map-ol": "16.0.0-next.5",
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
-        "@dlr-eoc/utils-maps": "16.0.0-next.5",
+        "@dlr-eoc/map-ol": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/utils-maps": "16.0.0-next.6",
         "proj4": "^2.17.0",
         "three": "^0.176.0",
         "tslib": "^2.6.3"
@@ -22778,7 +22778,7 @@
     },
     "projects/ngx-ukis-ui-clarity": {
       "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-devkit/core": "^19.2.19",
@@ -22803,10 +22803,10 @@
         "@cds/core": "^6.17.0",
         "@clr/angular": "^17.12.2",
         "@clr/ui": "^17.12.2",
-        "@dlr-eoc/map-ol": "16.0.0-next.5",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.5",
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
+        "@dlr-eoc/map-ol": "16.0.0-next.6",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
         "jsonc-parser": "^3.3.1",
         "ol": "^v10.8.0",
         "proj4": "^2.17.0",
@@ -22841,7 +22841,7 @@
     },
     "projects/ngx-ukis-utilities": {
       "name": "@dlr-eoc/ngx-ukis-utilities",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22855,15 +22855,15 @@
     },
     "projects/services-layers": {
       "name": "@dlr-eoc/services-layers",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.5",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22874,10 +22874,10 @@
     },
     "projects/services-map-state": {
       "name": "@dlr-eoc/services-map-state",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22892,14 +22892,14 @@
     },
     "projects/services-ogc": {
       "name": "@dlr-eoc/services-ogc",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-        "@dlr-eoc/services-layers": "16.0.0-next.5",
-        "@dlr-eoc/services-map-state": "16.0.0-next.5",
-        "@dlr-eoc/services-util-store": "16.0.0-next.5",
-        "@dlr-eoc/utils-ogc": "16.0.0-next.5",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/services-util-store": "16.0.0-next.6",
+        "@dlr-eoc/utils-ogc": "16.0.0-next.6",
         "jsonix": "^3.0.0",
         "luxon": "^3.6.1",
         "ogc-schemas": "^2.6.1",
@@ -22910,7 +22910,7 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/shared-assets": "16.0.0-next.5",
+        "@dlr-eoc/shared-assets": "16.0.0-next.6",
         "proj4": "^2.17.0",
         "terser": "^5.39.2",
         "zone.js": "~0.15.1"
@@ -22949,7 +22949,7 @@
     },
     "projects/services-util-store": {
       "name": "@dlr-eoc/services-util-store",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",
@@ -22966,13 +22966,13 @@
     },
     "projects/shared-assets": {
       "name": "@dlr-eoc/shared-assets",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
     "projects/utilities": {
       "name": "@dlr-eoc/utilities",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22984,7 +22984,7 @@
     },
     "projects/utils-browser": {
       "name": "@dlr-eoc/utils-browser",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/core": "^19.2.19",
@@ -22994,7 +22994,7 @@
     },
     "projects/utils-maps": {
       "name": "@dlr-eoc/utils-maps",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "delaunator": "^5.0.1",
@@ -23009,7 +23009,7 @@
     },
     "projects/utils-ogc": {
       "name": "@dlr-eoc/utils-ogc",
-      "version": "16.0.0-next.5",
+      "version": "16.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonix": "^3.0.0",
@@ -23026,7 +23026,7 @@
     },
     "scripts/library": {
       "name": "ukis-libraries-scripts",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ukis-frontend-libraries",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -22585,10 +22585,10 @@
     },
     "projects/base-layers-raster": {
       "name": "@dlr-eoc/base-layers-raster",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22599,10 +22599,10 @@
     },
     "projects/cookie-alert": {
       "name": "@dlr-eoc/cookie-alert",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-util-store": "16.0.0-next.7",
+        "@dlr-eoc/services-util-store": "16.0.0-next.8",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22615,13 +22615,13 @@
       }
     },
     "projects/demo-auth": {
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/cookie-alert": "16.0.0-next.7",
-        "@dlr-eoc/map-ol": "16.0.0-next.7",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/cookie-alert": "16.0.0-next.8",
+        "@dlr-eoc/map-ol": "16.0.0-next.8",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.8"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22638,18 +22638,18 @@
       }
     },
     "projects/demo-maps": {
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/map-cesium": "16.0.0-next.7",
-        "@dlr-eoc/map-maplibre": "16.0.0-next.7",
-        "@dlr-eoc/map-ol": "16.0.0-next.7",
-        "@dlr-eoc/map-three": "16.0.0-next.7",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
-        "@dlr-eoc/services-ogc": "16.0.0-next.7",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7",
-        "@dlr-eoc/utils-maps": "16.0.0-next.7"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/map-cesium": "16.0.0-next.8",
+        "@dlr-eoc/map-maplibre": "16.0.0-next.8",
+        "@dlr-eoc/map-ol": "16.0.0-next.8",
+        "@dlr-eoc/map-three": "16.0.0-next.8",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.8",
+        "@dlr-eoc/services-ogc": "16.0.0-next.8",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8",
+        "@dlr-eoc/utils-maps": "16.0.0-next.8"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22669,18 +22669,18 @@
     },
     "projects/map-cesium": {
       "name": "@dlr-eoc/map-cesium",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/engine": "^22.3.0",
         "@cesium/widgets": "^14.3.0",
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22690,19 +22690,19 @@
     },
     "projects/map-maplibre": {
       "name": "@dlr-eoc/map-maplibre",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
-        "@dlr-eoc/utilities": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
+        "@dlr-eoc/utilities": "16.0.0-next.8",
         "@mapbox/togeojson": "0.16.2",
         "maplibre-gl": "^5.5.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22712,12 +22712,12 @@
     },
     "projects/map-ol": {
       "name": "@dlr-eoc/map-ol",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
-        "@dlr-eoc/utils-maps": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
+        "@dlr-eoc/utils-maps": "16.0.0-next.8",
         "ol": "^v10.8.0",
         "ol-mapbox-style": "^13.2.1",
         "proj4": "^2.17.0",
@@ -22725,8 +22725,8 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22737,13 +22737,13 @@
     },
     "projects/map-three": {
       "name": "@dlr-eoc/map-three",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/map-ol": "16.0.0-next.7",
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
-        "@dlr-eoc/utils-maps": "16.0.0-next.7",
+        "@dlr-eoc/map-ol": "16.0.0-next.8",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
+        "@dlr-eoc/utils-maps": "16.0.0-next.8",
         "proj4": "^2.17.0",
         "three": "^0.176.0",
         "tslib": "^2.6.3"
@@ -22759,7 +22759,7 @@
     },
     "projects/ngx-ukis-ui-clarity": {
       "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-devkit/core": "^19.2.19",
@@ -22784,10 +22784,10 @@
         "@cds/core": "^6.17.0",
         "@clr/angular": "^17.12.2",
         "@clr/ui": "^17.12.2",
-        "@dlr-eoc/map-ol": "16.0.0-next.7",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/map-ol": "16.0.0-next.8",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.8",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
         "jsonc-parser": "^3.3.1",
         "ol": "^v10.8.0",
         "proj4": "^2.17.0",
@@ -22822,7 +22822,7 @@
     },
     "projects/ngx-ukis-utilities": {
       "name": "@dlr-eoc/ngx-ukis-utilities",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22836,15 +22836,15 @@
     },
     "projects/services-layers": {
       "name": "@dlr-eoc/services-layers",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.8",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22855,10 +22855,10 @@
     },
     "projects/services-map-state": {
       "name": "@dlr-eoc/services-map-state",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22873,14 +22873,14 @@
     },
     "projects/services-ogc": {
       "name": "@dlr-eoc/services-ogc",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-        "@dlr-eoc/services-layers": "16.0.0-next.7",
-        "@dlr-eoc/services-map-state": "16.0.0-next.7",
-        "@dlr-eoc/services-util-store": "16.0.0-next.7",
-        "@dlr-eoc/utils-ogc": "16.0.0-next.7",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+        "@dlr-eoc/services-layers": "16.0.0-next.8",
+        "@dlr-eoc/services-map-state": "16.0.0-next.8",
+        "@dlr-eoc/services-util-store": "16.0.0-next.8",
+        "@dlr-eoc/utils-ogc": "16.0.0-next.8",
         "jsonix": "^3.0.0",
         "luxon": "^3.6.1",
         "ogc-schemas": "^2.6.1",
@@ -22891,7 +22891,7 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/shared-assets": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.8",
         "proj4": "^2.17.0",
         "terser": "^5.39.2",
         "zone.js": "~0.15.1"
@@ -22930,7 +22930,7 @@
     },
     "projects/services-util-store": {
       "name": "@dlr-eoc/services-util-store",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",
@@ -22947,13 +22947,13 @@
     },
     "projects/shared-assets": {
       "name": "@dlr-eoc/shared-assets",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
     "projects/utilities": {
       "name": "@dlr-eoc/utilities",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22965,7 +22965,7 @@
     },
     "projects/utils-browser": {
       "name": "@dlr-eoc/utils-browser",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/core": "^19.2.19",
@@ -22975,7 +22975,7 @@
     },
     "projects/utils-maps": {
       "name": "@dlr-eoc/utils-maps",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "delaunator": "^5.0.1",
@@ -22990,7 +22990,7 @@
     },
     "projects/utils-ogc": {
       "name": "@dlr-eoc/utils-ogc",
-      "version": "16.0.0-next.7",
+      "version": "16.0.0-next.8",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonix": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ukis-frontend-libraries",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -22585,10 +22585,10 @@
     },
     "projects/base-layers-raster": {
       "name": "@dlr-eoc/base-layers-raster",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22599,10 +22599,10 @@
     },
     "projects/cookie-alert": {
       "name": "@dlr-eoc/cookie-alert",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-util-store": "16.0.0-next.6",
+        "@dlr-eoc/services-util-store": "16.0.0-next.7",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22615,13 +22615,13 @@
       }
     },
     "projects/demo-auth": {
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/cookie-alert": "16.0.0-next.6",
-        "@dlr-eoc/map-ol": "16.0.0-next.6",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/cookie-alert": "16.0.0-next.7",
+        "@dlr-eoc/map-ol": "16.0.0-next.7",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22638,18 +22638,18 @@
       }
     },
     "projects/demo-maps": {
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/map-cesium": "16.0.0-next.6",
-        "@dlr-eoc/map-maplibre": "16.0.0-next.6",
-        "@dlr-eoc/map-ol": "16.0.0-next.6",
-        "@dlr-eoc/map-three": "16.0.0-next.6",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
-        "@dlr-eoc/services-ogc": "16.0.0-next.6",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6",
-        "@dlr-eoc/utils-maps": "16.0.0-next.6"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/map-cesium": "16.0.0-next.7",
+        "@dlr-eoc/map-maplibre": "16.0.0-next.7",
+        "@dlr-eoc/map-ol": "16.0.0-next.7",
+        "@dlr-eoc/map-three": "16.0.0-next.7",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
+        "@dlr-eoc/services-ogc": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7",
+        "@dlr-eoc/utils-maps": "16.0.0-next.7"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
@@ -22669,18 +22669,18 @@
     },
     "projects/map-cesium": {
       "name": "@dlr-eoc/map-cesium",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/engine": "^22.3.0",
         "@cesium/widgets": "^14.3.0",
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22690,19 +22690,19 @@
     },
     "projects/map-maplibre": {
       "name": "@dlr-eoc/map-maplibre",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
-        "@dlr-eoc/utilities": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/utilities": "16.0.0-next.7",
         "@mapbox/togeojson": "0.16.2",
         "maplibre-gl": "^5.5.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6"
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7"
       },
       "peerDependencies": {
         "@angular/common": "^19.2.19",
@@ -22712,12 +22712,12 @@
     },
     "projects/map-ol": {
       "name": "@dlr-eoc/map-ol",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
-        "@dlr-eoc/utils-maps": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/utils-maps": "16.0.0-next.7",
         "ol": "^v10.8.0",
         "ol-mapbox-style": "^13.2.1",
         "proj4": "^2.17.0",
@@ -22725,8 +22725,8 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22737,13 +22737,13 @@
     },
     "projects/map-three": {
       "name": "@dlr-eoc/map-three",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/map-ol": "16.0.0-next.6",
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
-        "@dlr-eoc/utils-maps": "16.0.0-next.6",
+        "@dlr-eoc/map-ol": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/utils-maps": "16.0.0-next.7",
         "proj4": "^2.17.0",
         "three": "^0.176.0",
         "tslib": "^2.6.3"
@@ -22759,7 +22759,7 @@
     },
     "projects/ngx-ukis-ui-clarity": {
       "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-devkit/core": "^19.2.19",
@@ -22784,10 +22784,10 @@
         "@cds/core": "^6.17.0",
         "@clr/angular": "^17.12.2",
         "@clr/ui": "^17.12.2",
-        "@dlr-eoc/map-ol": "16.0.0-next.6",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
+        "@dlr-eoc/map-ol": "16.0.0-next.7",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
         "jsonc-parser": "^3.3.1",
         "ol": "^v10.8.0",
         "proj4": "^2.17.0",
@@ -22822,7 +22822,7 @@
     },
     "projects/ngx-ukis-utilities": {
       "name": "@dlr-eoc/ngx-ukis-utilities",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22836,15 +22836,15 @@
     },
     "projects/services-layers": {
       "name": "@dlr-eoc/services-layers",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22855,10 +22855,10 @@
     },
     "projects/services-map-state": {
       "name": "@dlr-eoc/services-map-state",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22873,14 +22873,14 @@
     },
     "projects/services-ogc": {
       "name": "@dlr-eoc/services-ogc",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-        "@dlr-eoc/services-layers": "16.0.0-next.6",
-        "@dlr-eoc/services-map-state": "16.0.0-next.6",
-        "@dlr-eoc/services-util-store": "16.0.0-next.6",
-        "@dlr-eoc/utils-ogc": "16.0.0-next.6",
+        "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+        "@dlr-eoc/services-layers": "16.0.0-next.7",
+        "@dlr-eoc/services-map-state": "16.0.0-next.7",
+        "@dlr-eoc/services-util-store": "16.0.0-next.7",
+        "@dlr-eoc/utils-ogc": "16.0.0-next.7",
         "jsonix": "^3.0.0",
         "luxon": "^3.6.1",
         "ogc-schemas": "^2.6.1",
@@ -22891,7 +22891,7 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^19.2.19",
-        "@dlr-eoc/shared-assets": "16.0.0-next.6",
+        "@dlr-eoc/shared-assets": "16.0.0-next.7",
         "proj4": "^2.17.0",
         "terser": "^5.39.2",
         "zone.js": "~0.15.1"
@@ -22930,7 +22930,7 @@
     },
     "projects/services-util-store": {
       "name": "@dlr-eoc/services-util-store",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",
@@ -22947,13 +22947,13 @@
     },
     "projects/shared-assets": {
       "name": "@dlr-eoc/shared-assets",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
     "projects/utilities": {
       "name": "@dlr-eoc/utilities",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22965,7 +22965,7 @@
     },
     "projects/utils-browser": {
       "name": "@dlr-eoc/utils-browser",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/core": "^19.2.19",
@@ -22975,7 +22975,7 @@
     },
     "projects/utils-maps": {
       "name": "@dlr-eoc/utils-maps",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "delaunator": "^5.0.1",
@@ -22990,7 +22990,7 @@
     },
     "projects/utils-ogc": {
       "name": "@dlr-eoc/utils-ogc",
-      "version": "16.0.0-next.6",
+      "version": "16.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonix": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,7 +478,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.19.tgz",
       "integrity": "sha512-XGChk+26XZpcwzIQUVjgLxGVC//m5TaDrogseQNIGs2Chzv6KYbo91HftL69fTiM5udRYjg6IV7XEzDNF/GVUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -511,7 +510,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.21.tgz",
       "integrity": "sha512-fCrwCY4uLvgpoOheM0XS/xE0rRLiqZfKoiOvbwuWQWEm12UiHxPUyoy87hUMArgTJkKAtstOpKixep1RNst1BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.1902.21",
         "@angular-devkit/core": "19.2.21",
@@ -565,7 +563,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.19.tgz",
       "integrity": "sha512-/JYo8jJZ6BAgw3IVYJpinAfGb+RbaZubrElFvaq450BWxDPInv7Z99HKEQ3qEBRsBeIAQ/WrKXDxoJSjy7QMNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -582,7 +579,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.19.tgz",
       "integrity": "sha512-kWlqFW7ExvAqKv+X/6ZsWVW7YTmI1/3VUvADLC/6bkLTdKrHS8OtBHfsklXmHMNVbbFopTvoTeKkoqLGrW2lwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -596,7 +592,6 @@
       "integrity": "sha512-vdMJX9E7wePN41T+6BYRQBA+XiR9a5DBhs20dqtv8YVireQktH6mxLZIg1pVxkL/gnao2gpl/lOvp0xmC7UN/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -673,7 +668,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.19.tgz",
       "integrity": "sha512-VZAzpxBoQgyy7AOlhxbAHxPQWo0nk8xsnrD36PLCZeTZA/5GNzO3lLVaX2N5BCUgpgiCBjNBKq9kVo6ZkAls9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -690,7 +684,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.19.tgz",
       "integrity": "sha512-J09++utTVaPs962y/adeDjIgqyhzNpnzAS7Nex+HNy/LnWPcTNW781cOh1EGS1X/+CmgnI8HWs5z4KGeBeU1aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -719,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.19.tgz",
       "integrity": "sha512-bnQSmoJNI1LQxJnHnB01XQXqgOdgAtLAOsa24ZT6b2pWV3Vw0/7+V2dZsNZX/TJtejunvSgSDCEqgJhIQ5vBVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -742,7 +734,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.19.tgz",
       "integrity": "sha512-u8aYmIRGtx4yOXhmqgiRIm+DyH+05bAkzMHr6RE0JV/wxVJmAIKZnquHM6ItFvF0eV0pfMTPwArmRuHVWu7tQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -761,7 +752,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.19.tgz",
       "integrity": "sha512-zh40ihKgYOM5pjgUOLlUKdWYsGgEj7MQHgzdV1E9Zz6LBrQTp/PGS/UdCQn88H6KAshR0uXrkc/vP+tnB2jqdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -815,7 +805,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2498,7 +2487,6 @@
       "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.17.0.tgz",
       "integrity": "sha512-afG+KwNE4BDc6CAylgGbJrJUeGYFbOIfagylaqqbS7fgIX2h3ZqFcUOv/2hujSZ9GZiuCSa+A/BkJi7K83QEgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lit": "^2.1.3",
         "ramda": "^0.29.0",
@@ -2571,7 +2559,6 @@
       "resolved": "https://registry.npmjs.org/@clr/angular/-/angular-17.12.2.tgz",
       "integrity": "sha512-KsrQBiOX0vKf/mvrw1p9gN8en6d5Na03fD4GeNSqYLBDVh/huxQf4705mam7SDStS4LEkG74Kfug2j39r7hdHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2588,7 +2575,6 @@
       "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-17.12.2.tgz",
       "integrity": "sha512-47hNWtt5pRt21FuSbl7LWDT+HkMY914l4ub2D8eFL1ETLuaoAlbwgSHxepxn8ITg/xFY2kBVeiwlYx1a4bxwhA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@cds/core": "^6.9.2"
       }
@@ -2715,7 +2701,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2973,7 +2958,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -4142,7 +4126,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -6732,7 +6715,6 @@
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.21.tgz",
       "integrity": "sha512-3Nxac8jJJIwGTgP3xLVLmqUyyZAM/9WtDUbZurKXl8xLWo5nHLIVXq/1FSPOhwVYEAZj6OrstaCPsDxflNdfOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "19.2.21",
         "@angular-devkit/schematics": "19.2.21",
@@ -7117,7 +7099,8 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -7716,7 +7699,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7790,7 +7772,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8528,7 +8509,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9064,7 +9044,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -9343,7 +9322,6 @@
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -9366,16 +9344,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/codelyzer/node_modules/zone.js": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
       "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -10731,6 +10707,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -10751,6 +10737,19 @@
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -13432,8 +13431,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.13.0.tgz",
       "integrity": "sha512-vsYjfh7lyqvZX5QgqKc4YH8phs7g96Z8bsdIFNEU3VqXhlHaq+vov/Fgn/sr6MiUczdZkyXRC3TX369Ll4Nzbw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -13667,7 +13665,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13790,8 +13787,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -13913,7 +13909,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -14398,7 +14393,6 @@
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -15676,7 +15670,6 @@
       "integrity": "sha512-dFuwFsDJMBSd1YtmLLcX5bNNUCQUlRqgf34aXA+79PmkOP+0eF8GP2949wq3+jMjmFTNm80Oo8IUYiSLwklKCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/wasm-node": "^4.24.0",
@@ -16237,7 +16230,6 @@
       "resolved": "https://registry.npmjs.org/ol/-/ol-10.8.0.tgz",
       "integrity": "sha512-kLk7jIlJvKyhVMAjORTXKjzlM6YIByZ1H/d0DBx3oq8nSPCG6/gbLr5RxukzPgwbhnAqh+xHNCmrvmFKhVMvoQ==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
@@ -17110,7 +17102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -17280,7 +17271,6 @@
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.2.tgz",
       "integrity": "sha512-ipfBRfQly0HhHTO7hnC1GfaX8bvroO7VV4KH889ehmADSE8C/qzp2j+Jj6783S9Tj6c2qX/hhYm7oH0kgXzBAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.5.1"
@@ -18481,7 +18471,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20053,7 +20042,6 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -20359,8 +20347,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -20369,7 +20356,6 @@
       "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -20679,7 +20665,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20962,7 +20947,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -21712,7 +21696,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21828,7 +21811,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -22444,7 +22426,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "projectsScope": "@dlr-eoc/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "projectsScope": "@dlr-eoc/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "projectsScope": "@dlr-eoc/",

--- a/projects/base-layers-raster/package.json
+++ b/projects/base-layers-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/base-layers-raster",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -13,7 +13,7 @@
     "OSM"
   ],
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/base-layers-raster/package.json
+++ b/projects/base-layers-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/base-layers-raster",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -13,7 +13,7 @@
     "OSM"
   ],
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/base-layers-raster/package.json
+++ b/projects/base-layers-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/base-layers-raster",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -13,7 +13,7 @@
     "OSM"
   ],
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/cookie-alert/package.json
+++ b/projects/cookie-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/cookie-alert",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -16,7 +16,7 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-util-store": "16.0.0-next.6",
+    "@dlr-eoc/services-util-store": "16.0.0-next.7",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/cookie-alert/package.json
+++ b/projects/cookie-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/cookie-alert",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -16,7 +16,7 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-util-store": "16.0.0-next.5",
+    "@dlr-eoc/services-util-store": "16.0.0-next.6",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/cookie-alert/package.json
+++ b/projects/cookie-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/cookie-alert",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -16,7 +16,7 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-util-store": "16.0.0-next.7",
+    "@dlr-eoc/services-util-store": "16.0.0-next.8",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/demo-auth/package.json
+++ b/projects/demo-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-auth",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,10 +21,10 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.6",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
-    "@dlr-eoc/cookie-alert": "16.0.0-next.6",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6"
+    "@dlr-eoc/map-ol": "16.0.0-next.7",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
+    "@dlr-eoc/cookie-alert": "16.0.0-next.7",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-auth/package.json
+++ b/projects/demo-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-auth",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,10 +21,10 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.7",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
-    "@dlr-eoc/cookie-alert": "16.0.0-next.7",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7"
+    "@dlr-eoc/map-ol": "16.0.0-next.8",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.8",
+    "@dlr-eoc/cookie-alert": "16.0.0-next.8",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-auth/package.json
+++ b/projects/demo-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-auth",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,10 +21,10 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.5",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.5",
-    "@dlr-eoc/cookie-alert": "16.0.0-next.5",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5"
+    "@dlr-eoc/map-ol": "16.0.0-next.6",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
+    "@dlr-eoc/cookie-alert": "16.0.0-next.6",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/package.json
+++ b/projects/demo-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-maps",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -22,15 +22,15 @@
     "proj4": "^2.17.0"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.6",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-    "@dlr-eoc/map-three": "16.0.0-next.6",
-    "@dlr-eoc/utils-maps": "16.0.0-next.6",
-    "@dlr-eoc/services-ogc": "16.0.0-next.6",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6",
-    "@dlr-eoc/map-cesium": "16.0.0-next.6",
-    "@dlr-eoc/map-maplibre": "16.0.0-next.6"
+    "@dlr-eoc/map-ol": "16.0.0-next.7",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+    "@dlr-eoc/map-three": "16.0.0-next.7",
+    "@dlr-eoc/utils-maps": "16.0.0-next.7",
+    "@dlr-eoc/services-ogc": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7",
+    "@dlr-eoc/map-cesium": "16.0.0-next.7",
+    "@dlr-eoc/map-maplibre": "16.0.0-next.7"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/package.json
+++ b/projects/demo-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-maps",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -22,15 +22,15 @@
     "proj4": "^2.17.0"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.5",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.5",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-    "@dlr-eoc/map-three": "16.0.0-next.5",
-    "@dlr-eoc/utils-maps": "16.0.0-next.5",
-    "@dlr-eoc/services-ogc": "16.0.0-next.5",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5",
-    "@dlr-eoc/map-cesium": "16.0.0-next.5",
-    "@dlr-eoc/map-maplibre": "16.0.0-next.5"
+    "@dlr-eoc/map-ol": "16.0.0-next.6",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.6",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+    "@dlr-eoc/map-three": "16.0.0-next.6",
+    "@dlr-eoc/utils-maps": "16.0.0-next.6",
+    "@dlr-eoc/services-ogc": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6",
+    "@dlr-eoc/map-cesium": "16.0.0-next.6",
+    "@dlr-eoc/map-maplibre": "16.0.0-next.6"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/package.json
+++ b/projects/demo-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-maps",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -22,15 +22,15 @@
     "proj4": "^2.17.0"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0-next.7",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.7",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-    "@dlr-eoc/map-three": "16.0.0-next.7",
-    "@dlr-eoc/utils-maps": "16.0.0-next.7",
-    "@dlr-eoc/services-ogc": "16.0.0-next.7",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7",
-    "@dlr-eoc/map-cesium": "16.0.0-next.7",
-    "@dlr-eoc/map-maplibre": "16.0.0-next.7"
+    "@dlr-eoc/map-ol": "16.0.0-next.8",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0-next.8",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+    "@dlr-eoc/map-three": "16.0.0-next.8",
+    "@dlr-eoc/utils-maps": "16.0.0-next.8",
+    "@dlr-eoc/services-ogc": "16.0.0-next.8",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8",
+    "@dlr-eoc/map-cesium": "16.0.0-next.8",
+    "@dlr-eoc/map-maplibre": "16.0.0-next.8"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.html
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.html
@@ -1,0 +1,17 @@
+<div class="extent-helper-container">
+    <p>
+        <b>WGS84Extent:</b> {{currentMapState.extent | json}}
+    </p>
+    <p>
+        <b>Center:</b> {{currentMapState.center | json}}
+    </p>
+    <p>
+        <b>Zoom:</b> {{currentMapState.zoom}}
+    </p>
+    <p>
+        <b>Proj:</b> {{currentMapState.epsg}}
+    </p>
+    <p>
+        <b>NativeExtent:</b> {{currentMapState.nativeExtent | json}}
+    </p>
+</div>

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.html
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.html
@@ -9,7 +9,7 @@
         <b>Zoom:</b> {{currentMapState.zoom}}
     </p>
     <p>
-        <b>Proj:</b> {{currentMapState.epsg}}
+        <b>Proj:</b> {{currentMapState.proj?.epsg}}
     </p>
     <p>
         <b>NativeExtent:</b> {{currentMapState.nativeExtent | json}}

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.scss
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.scss
@@ -1,0 +1,3 @@
+.extent-helper-container{
+    padding: 0 0.5rem;
+}

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.spec.ts
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExtentHelperComponent } from './extent-helper.component';
+
+describe('ExtentHelperComponent', () => {
+  let component: ExtentHelperComponent;
+  let fixture: ComponentFixture<ExtentHelperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+    imports: [ExtentHelperComponent]
+})
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ExtentHelperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.ts
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { MapStateService, MapState } from '@dlr-eoc/services-map-state';
 import { Subscription } from 'rxjs';
 import { JsonPipe } from '@angular/common';
-import { MapOlService } from '@dlr-eoc/map-ol';
 
 @Component({
   selector: 'app-extent-helper',

--- a/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.ts
+++ b/projects/demo-maps/src/app/components/extent-helper/extent-helper.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { MapStateService, MapState } from '@dlr-eoc/services-map-state';
+import { Subscription } from 'rxjs';
+import { JsonPipe } from '@angular/common';
+import { MapOlService } from '@dlr-eoc/map-ol';
+
+@Component({
+  selector: 'app-extent-helper',
+  templateUrl: './extent-helper.component.html',
+  styleUrls: ['./extent-helper.component.scss'],
+  imports: [JsonPipe]
+})
+export class ExtentHelperComponent implements OnInit, OnDestroy {
+
+  @Input('mapStateSvc') mapStateSvc!: MapStateService;
+  subs: Subscription[] = [];
+  public currentMapState!: MapState;
+  constructor() { }
+
+  ngOnInit(): void {
+    if (this.mapStateSvc) {
+      const mapStateSub = this.mapStateSvc.getMapState().subscribe(state => {
+        this.currentMapState = state;
+      });
+      this.subs.push(mapStateSub);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
+  }
+
+}

--- a/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-cesium/route-example-cesium.component.ts
@@ -171,8 +171,7 @@ export class RouteExampleCesiumComponent implements OnInit, OnDestroy {
           TRANSPARENT: true
         },
         expanded: false,
-        popup: true,
-        time: new Date().toISOString()
+        popup: true
       }),
       new WmsLayer({
         type: 'wms',

--- a/projects/demo-maps/src/app/route-components/route-example-events/route-map3.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-events/route-map3.component.html
@@ -15,7 +15,7 @@
     <cds-icon shape="compass" clrVerticalNavIcon></cds-icon>
     Coordinates
     <clr-vertical-nav-group-children class="padding title-ellipsis">
-      <ukis-mouse-position></ukis-mouse-position>
+      <ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc"></ukis-mouse-position>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
 

--- a/projects/demo-maps/src/app/route-components/route-example-olperformance/route-map7.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-olperformance/route-map7.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, HostBinding, AfterViewInit } from '@angular/core';
 import { LayersService } from '@dlr-eoc/services-layers';
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { MapStateService, EPSG_4326_Def } from '@dlr-eoc/services-map-state';
 import { MapOlService, IMapControls } from '@dlr-eoc/map-ol';
 import { OsmTileLayer } from '@dlr-eoc/base-layers-raster';
 import { LargeLayersService } from './services/largelayers.service';
@@ -39,7 +39,8 @@ export class RouteMap7Component implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
-    this.mapSvc.setProjection('EPSG:4326');
+    // this.mapSvc.setProjection(EPSG_4326_Def);
+    this.mapStateSvc.setProjection(EPSG_4326_Def.code);
 
     const styleFunc = (feature: Feature<any>, resolution: number) => {
       const fullId = feature.getId().toString();

--- a/projects/demo-maps/src/app/route-components/route-example-olperformance/route-map7.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-olperformance/route-map7.component.ts
@@ -15,11 +15,11 @@ import { LayerControlComponent } from '@dlr-eoc/ngx-ukis-ui-clarity';
 ClarityIcons.addIcons(...[layersIcon, layersIcon, clockIcon]);
 
 @Component({
-    selector: 'app-route-map7',
-    templateUrl: './route-map7.component.html',
-    styleUrls: ['./route-map7.component.scss'],
-    providers: [LayersService, MapStateService, MapOlService],
-    imports: [MapOlComponent, ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule, PerformanceComponent, LayerControlComponent]
+  selector: 'app-route-map7',
+  templateUrl: './route-map7.component.html',
+  styleUrls: ['./route-map7.component.scss'],
+  providers: [LayersService, MapStateService, MapOlService],
+  imports: [MapOlComponent, ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule, PerformanceComponent, LayerControlComponent]
 })
 export class RouteMap7Component implements OnInit, AfterViewInit {
   @HostBinding('class') class = 'content-container';
@@ -39,9 +39,7 @@ export class RouteMap7Component implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
-    // this.mapSvc.setProjection(EPSG_4326_Def);
-    this.mapStateSvc.setProjection(EPSG_4326_Def.code);
-
+    this.mapStateSvc.setProjection(EPSG_4326_Def);
     const styleFunc = (feature: Feature<any>, resolution: number) => {
       const fullId = feature.getId().toString();
       const idStr = fullId.match(/(\d+)/)[0];
@@ -81,17 +79,8 @@ export class RouteMap7Component implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    const extent = [-107.14, 51.85, -106.14, 52.33] as [number, number, number, number];
-    /**
-     * Currently, there is a small bug in mapStateSvc.setExtent:
-     * this method does not work as long as the 'duration' parameter is given.
-     * As a short-term workaround, we work on the olMap directly.
-     */
-    // this.mapStateSvc.setExtent(extent);
-    this.mapSvc.map.getView().fit(
-      extent, {
-      size: this.mapSvc.map.getSize(),
-    });
+    const extent = [-107.14, 51.85, -106.14, 52.33] as [number, number, number, number]
+    this.mapStateSvc.setExtent(extent);
   }
 
 }

--- a/projects/demo-maps/src/app/route-components/route-example-olperformance/services/largelayers.service.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-olperformance/services/largelayers.service.ts
@@ -7,12 +7,10 @@ import { MVT } from 'ol/format';
 import { VectorTile as VectorTileLayer } from 'ol/layer';
 import { VectorTile as VectorTileSource } from 'ol/source';
 import { GeoJSON } from 'ol/format';
-import { get as getProjection, getTransform } from 'ol/proj';
 import { HttpClient } from '@angular/common/http';
 import { CustomLayer } from '@dlr-eoc/services-layers';
 import { MapOlService } from '@dlr-eoc/map-ol';
 import { all, bbox } from 'ol/loadingstrategy';
-import { IProjDef } from '@dlr-eoc/services-map-state';
 
 
 export type DataStrategy = 'all' | 'bbox' | 'tile' | 'simplifyGeometry' | 'noProps';
@@ -28,20 +26,8 @@ export class LargeLayersService {
 
   constructor(
     private http: HttpClient,
-    private olSvc: MapOlService
+    private mapOlSvc: MapOlService
   ) {
-    const IndianaWest: IProjDef = {
-      code: 'EPSG:2966',
-      proj4js: '+proj=tmerc +lat_0=37.5 +lon_0=-87.08333333333333 +k=0.999966667 +x_0=900000 +y_0=249999.9998983998 +datum=NAD83 +units=us-ft +no_defs',
-      title: 'NAD83 / Indiana West',
-      extent: [2658876.73, 918525.73, 3618576.69, 2383977.36],
-      worldExtent: [-88.1, 37.77, -84.78, 41.77],
-      global: false,
-      units: 'degrees'
-    }
-    this.olSvc.registerProjection(IndianaWest);
-    const newProj = getProjection('EPSG:2966');
-    const toWgs84 = getTransform(newProj, 'EPSG:4326');
 
     this.geojson2966To4326 = new GeoJSON({
       dataProjection: 'EPSG:2966',
@@ -58,7 +44,7 @@ export class LargeLayersService {
       case 'all':
         return new VectorSource({
           format: new GeoJSON(),
-          url: this.getRequestUrl(this.olSvc.EPSG),
+          url: this.getRequestUrl(this.mapOlSvc.EPSG),
           strategy: all
         });
 

--- a/projects/demo-maps/src/app/route-components/route-example-olperformance/services/largelayers.service.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-olperformance/services/largelayers.service.ts
@@ -8,12 +8,11 @@ import { VectorTile as VectorTileLayer } from 'ol/layer';
 import { VectorTile as VectorTileSource } from 'ol/source';
 import { GeoJSON } from 'ol/format';
 import { get as getProjection, getTransform } from 'ol/proj';
-import { register } from 'ol/proj/proj4';
-import proj4 from 'proj4';
 import { HttpClient } from '@angular/common/http';
 import { CustomLayer } from '@dlr-eoc/services-layers';
 import { MapOlService } from '@dlr-eoc/map-ol';
 import { all, bbox } from 'ol/loadingstrategy';
+import { IProjDef } from '@dlr-eoc/services-map-state';
 
 
 export type DataStrategy = 'all' | 'bbox' | 'tile' | 'simplifyGeometry' | 'noProps';
@@ -31,8 +30,16 @@ export class LargeLayersService {
     private http: HttpClient,
     private olSvc: MapOlService
   ) {
-    proj4.defs('EPSG:2966', '+proj=tmerc +lat_0=37.5 +lon_0=-87.08333333333333 +k=0.999966667 +x_0=900000 +y_0=249999.9998983998 +datum=NAD83 +units=us-ft +no_defs');
-    register(proj4);
+    const IndianaWest: IProjDef = {
+      code: 'EPSG:2966',
+      proj4js: '+proj=tmerc +lat_0=37.5 +lon_0=-87.08333333333333 +k=0.999966667 +x_0=900000 +y_0=249999.9998983998 +datum=NAD83 +units=us-ft +no_defs',
+      title: 'NAD83 / Indiana West',
+      extent: [2658876.73, 918525.73, 3618576.69, 2383977.36],
+      worldExtent: [-88.1, 37.77, -84.78, 41.77],
+      global: false,
+      units: 'degrees'
+    }
+    this.olSvc.registerProjection(IndianaWest);
     const newProj = getProjection('EPSG:2966');
     const toWgs84 = getTransform(newProj, 'EPSG:4326');
 

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
@@ -33,4 +33,19 @@
       <ukis-map-navigator [mapState]="mapStateSvc"></ukis-map-navigator>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
+  <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers" title="Extent">
+    <cds-icon shape="compass" clrVerticalNavIcon></cds-icon>
+    Extent
+    <clr-vertical-nav-group-children class="padding title-ellipsis">
+      <app-extent-helper [mapStateSvc]="mapStateSvc"></app-extent-helper>
+    </clr-vertical-nav-group-children>
+  </clr-vertical-nav-group>
+  <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers">
+    <cds-icon shape="cog" title="Actions" clrVerticalNavIcon></cds-icon>
+    Actions
+    <clr-vertical-nav-group-children class="padding title-ellipsis">
+      <button class="btn btn-primary" (click)="setExtent()">set Extent (Antarctic)</button>
+      <button class="btn btn-primary" (click)="setNewProjection()">set Projection and bbox (Antarctic)</button>
+    </clr-vertical-nav-group-children>
+  </clr-vertical-nav-group>
 </clr-vertical-nav>

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
@@ -46,6 +46,7 @@
     <clr-vertical-nav-group-children class="padding title-ellipsis">
       <button class="btn btn-primary" (click)="setExtent()">set Extent (Antarctic)</button>
       <button class="btn btn-primary" (click)="setNewProjection()">set Projection and bbox (Antarctic)</button>
+      <button class="btn btn-primary" (click)="addLayer()">Add Swiss GeoJSON Layer</button>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
 </clr-vertical-nav>

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
@@ -16,14 +16,14 @@
     <clr-vertical-nav-group-children class="padding title-ellipsis">
       On change, the map will fit to the new Projection extent. See "fitViewToNewExtent" Input
       <p></p>
-      <ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections" [fitViewToNewExtent]="true"></ukis-projection-switch>
+      <ukis-projection-switch [mapSvc]="mapSvc" [mapState]="mapStateSvc" [projectionList]="projections" [fitViewToNewExtent]="true"></ukis-projection-switch>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers" title="Coordinates">
     <cds-icon shape="compass" clrVerticalNavIcon></cds-icon>
     Coordinates
     <clr-vertical-nav-group-children class="padding title-ellipsis">
-      <ukis-mouse-position></ukis-mouse-position>
+      <ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc"></ukis-mouse-position>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers" title="Navigator">

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -1,21 +1,22 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
-import { LayersService, RasterLayer, VectorLayer } from '@dlr-eoc/services-layers';
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { LayersService, RasterLayer, TGeoExtent, VectorLayer } from '@dlr-eoc/services-layers';
+import { EPSG_3031_Def, EPSG_3995_Def, IProjDef, MapStateService, EPSG_3857_Def } from '@dlr-eoc/services-map-state';
 import { MapOlService, IMapControls, MapOlComponent } from '@dlr-eoc/map-ol';
 import { OsmTileLayer } from '@dlr-eoc/base-layers-raster';
 
 import { ClarityIcons, layersIcon, mapIcon, compassIcon } from '@cds/core/icon';
 import { ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule } from '@clr/angular';
-import { LayerControlComponent, IProjDef, ProjectionSwitchComponent, MousePositionComponent, MapNavigatorComponent } from '@dlr-eoc/ngx-ukis-ui-clarity';
+import { LayerControlComponent, ProjectionSwitchComponent, MousePositionComponent, MapNavigatorComponent } from '@dlr-eoc/ngx-ukis-ui-clarity';
+import { ExtentHelperComponent } from "../../components/extent-helper/extent-helper.component";
 ClarityIcons.addIcons(...[layersIcon, mapIcon, compassIcon]);
 
 @Component({
-    selector: 'app-route-map2',
-    templateUrl: './route-map2.component.html',
-    styleUrls: ['./route-map2.component.scss'],
-    /** use differnt instances of the services only for testing with diffenr routs  */
-    providers: [LayersService, MapStateService, MapOlService],
-    imports: [MapOlComponent, ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule, LayerControlComponent, ProjectionSwitchComponent, MousePositionComponent, MapNavigatorComponent]
+  selector: 'app-route-map2',
+  templateUrl: './route-map2.component.html',
+  styleUrls: ['./route-map2.component.scss'],
+  /** use differnt instances of the services only for testing with diffenr routs  */
+  providers: [LayersService, MapStateService, MapOlService],
+  imports: [MapOlComponent, ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule, LayerControlComponent, ProjectionSwitchComponent, MousePositionComponent, MapNavigatorComponent, ExtentHelperComponent]
 })
 export class RouteMap2Component implements OnInit {
   @HostBinding('class') class = 'content-container';
@@ -32,36 +33,6 @@ export class RouteMap2Component implements OnInit {
       scaleLine: true
     };
 
-    const arcticPolarStereographic: IProjDef = {
-      code: 'EPSG:3995',
-      proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
-      title: 'Arctic Polar Stereographic',
-      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
-      worldExtent: [-180.0, 60.0, 180.0, 90.0],
-      global: true,
-      units: 'm'
-    };
-
-    const antarcticPolarStereographic: IProjDef = {
-      code: `EPSG:3031`,
-      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
-      title: 'Antarctic Polar Stereographic',
-      extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
-      worldExtent: [-180.0, -90.0, 180.0, -60.0],
-      global: true,
-      units: 'm'
-    };
-
-    const webMercator: IProjDef = {
-      code: `EPSG:3857`,
-      proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
-      title: 'Spherical Mercator',
-      extent: [-20037508.34, -20048966.1, 20037508.34, 20048966.1],
-      worldExtent: [-180.0, -85.06, 180.0, 85.06],
-      global: true,
-      units: 'm'
-    };
-
     const SwissCH1903: IProjDef = {
       code: `EPSG:21781`,
       proj4js: '+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs +type=crs',
@@ -72,13 +43,23 @@ export class RouteMap2Component implements OnInit {
       units: 'm'
     };
 
-    this.projections = [webMercator, arcticPolarStereographic, antarcticPolarStereographic, SwissCH1903];
+    const ESRI_53034: IProjDef = {
+      code: 'ESRI:53034',
+      proj4js: '+proj=cea +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +R=6371000 +units=m +no_defs +type=crs',
+      title: 'Cylindrical Equal Area',
+      extent: [-20015086.8, -6371000.0, 20015086.8, 6371000.0],
+      worldExtent: [-180.0, -90.0, 180.0, 90.0],
+      global: true,
+      units: 'm'
+    }
+
+    this.projections = [EPSG_3857_Def, EPSG_3995_Def, EPSG_3031_Def, SwissCH1903, ESRI_53034];
     this.addOverlays();
     /** 
        * set map extent or IMapState (zoom, center...) with the MapStateService 
        * Check if the Extent is valid for the set projection.
        */
-      this.mapStateSvc.setExtent([-14, 33, 40, 57]);
+    this.mapStateSvc.setExtent([-14, 33, 40, 57]);
 
   }
 
@@ -161,6 +142,22 @@ export class RouteMap2Component implements OnInit {
 
     const overlays = [osm_layer, gufLayer, vectorLayer];
     overlays.map(layer => this.layersSvc.addLayer(layer, 'Layers'));
+  }
+
+  setExtent() {
+    const nativeBbox: TGeoExtent = [-2166686.6992718857, 532310.7393676594, -2089422.303209693, 594837.26196001];
+    const wgs84bbox: TGeoExtent = [-76.19697134976582, -70.34272872293334, -74.10888626456216, -69.53237850373523];
+
+    // this.mapStateSvc.setExtent(wgs84bbox);
+    this.mapStateSvc.setNativeExtent(nativeBbox);
+  }
+
+  setNewProjection() {
+    const nativeBbox: TGeoExtent = [-2166686.6992718857, 532310.7393676594, -2089422.303209693, 594837.26196001];
+    const wgs84bbox: TGeoExtent = [-76.19697134976582, -70.34272872293334, -74.10888626456216, -69.53237850373523];
+    const proJ = this.projections.find(p => p.title === 'Antarctic Polar Stereographic');
+    this.mapStateSvc.registerProjection(proJ);
+    this.mapStateSvc.setProjection(proJ.code, 'user', { fitToNativeBbox: nativeBbox });
   }
 
 }

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -8,6 +8,7 @@ import { ClarityIcons, layersIcon, mapIcon, compassIcon } from '@cds/core/icon';
 import { ClrVerticalNavModule, ClrStandaloneCdkTrapFocus, ClrNavigationModule, ClrIconModule } from '@clr/angular';
 import { LayerControlComponent, ProjectionSwitchComponent, MousePositionComponent, MapNavigatorComponent } from '@dlr-eoc/ngx-ukis-ui-clarity';
 import { ExtentHelperComponent } from "../../components/extent-helper/extent-helper.component";
+import { delay } from 'rxjs/operators';
 ClarityIcons.addIcons(...[layersIcon, mapIcon, compassIcon]);
 
 @Component({
@@ -53,7 +54,17 @@ export class RouteMap2Component implements OnInit {
       units: 'm'
     }
 
-    this.projections = [EPSG_3857_Def, EPSG_3995_Def, EPSG_3031_Def, SwissCH1903, ESRI_53034];
+    const ETRS89_UTM_37N: IProjDef = {
+      code: 'EPSG:25837',
+      proj4js: '+proj=utm +zone=37 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs',
+      title: 'UTM zone 37N',
+      extent: [-4861198.58, 3680548.11, 489848.43, 9660688.94],
+      worldExtent: [-16.1, 33.26, 38.01, 84.73],
+      global: false,
+      units: 'm'
+    }
+
+    this.projections = [EPSG_3857_Def, EPSG_3995_Def, EPSG_3031_Def, SwissCH1903, ESRI_53034, ETRS89_UTM_37N];
     this.addOverlays();
     /** 
        * set map extent or IMapState (zoom, center...) with the MapStateService 
@@ -65,12 +76,11 @@ export class RouteMap2Component implements OnInit {
 
 
   ngOnInit(): void {
-    this.mapStateSvc.getMapState().subscribe(state => {
-      console.log('MapState change', state);
-    });
-
-    this.mapSvc.projectionChange.subscribe(proj => {
+    this.mapStateSvc.getProjection().pipe(delay(300)).subscribe(proj => {
       console.log('Map Proj change', proj);
+      if (proj.epsg === 'EPSG:21781') {
+        this.addLayer();
+      }
     });
   }
 
@@ -137,10 +147,94 @@ export class RouteMap2Component implements OnInit {
           }
         ]
       },
-      visible: true
+      visible: true,
+      bbox: [12.122762285148893, 45.75982471322655, 22.585503751196956, 52.936158926509194]
     });
 
-    const overlays = [osm_layer, gufLayer, vectorLayer];
+    const vectorLayerPolar = new VectorLayer({
+      id: 'geojson_test_PolarDEM',
+      name: 'GeoJSON Vector Layer (PolarDEM)',
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+              "coordinates": [
+                [
+                  [
+                    -56.610291493162265,
+                    -63.14567134729959
+                  ],
+                  [
+                    -65.55445992781995,
+                    -65.42656926101324
+                  ],
+                  [
+                    -73.57228421370289,
+                    -70.01891446525254
+                  ],
+                  [
+                    -79.9666203974736,
+                    -72.86460180838449
+                  ],
+                  [
+                    -83.04719665248149,
+                    -74.13173444180848
+                  ],
+                  [
+                    -55.69191893422601,
+                    -75.70732872975574
+                  ],
+                  [
+                    -59.942004469019835,
+                    -72.39072889158679
+                  ],
+                  [
+                    -61.35730570181974,
+                    -67.91201652998802
+                  ],
+                  [
+                    -56.610291493162265,
+                    -63.14567134729959
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            }
+          }
+        ]
+      },
+      visible: true,
+      bbox: [-85.02702775046276, -75.78913027273286, -49.34343400046277, -62.95113726720521],
+      nativeBbox: {
+        epsg: 'EPSG:3031',
+        bbox: [-2788223.8152697003, 180971.96438660682, -1093301.5018768182, 1969824.701551262]
+      }
+    });
+
+    const TanDEMPolarDEM = new RasterLayer({
+      type: 'wms',
+      url: 'https://geoservice.dlr.de/eoc/elevation/wms',
+      name: 'TanDEM-X PolarDEM Antarctica',
+      id: 'TDM_POLARDEM90_ANT_HSC',
+      params: {
+        layers: 'TDM_POLARDEM90_ANT_HSC'
+      },
+      visible: false,
+      description: 'A hillshade generated from the TanDEM-X PolarDEM 90m elevation layer. This shading represents a combination slope and oblique shading.',
+      attribution: 'PolarDEM Data &copy; DLR/EOC licensed for <a href="https://geoservice.dlr.de/resources/licenses/polardem90/License_for_the_Utilization_of_TanDEM-X-PolarDEM_90m_for_Scientific_Use.pdf">scientific use</a>',
+      legendImg: '',
+      bbox: [-180, -90, 180, -56.22686667234951],
+      nativeBbox: {
+        epsg: 'EPSG:3031',
+        bbox: [-2699955, -2532555, 2799855, 2398455]
+      }
+    })
+
+    const overlays = [osm_layer, gufLayer, vectorLayer, TanDEMPolarDEM, vectorLayerPolar];
     overlays.map(layer => this.layersSvc.addLayer(layer, 'Layers'));
   }
 
@@ -158,6 +252,72 @@ export class RouteMap2Component implements OnInit {
     const proJ = this.projections.find(p => p.title === 'Antarctic Polar Stereographic');
     this.mapStateSvc.registerProjection(proJ);
     this.mapStateSvc.setProjection(proJ.code, 'user', { fitToNativeBbox: nativeBbox });
+  }
+
+  addLayer() {
+    const vectorLayerSwiss = new VectorLayer({
+      id: 'geojson_test_Swiss',
+      name: 'GeoJSON Vector Layer (Swiss)',
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+              "coordinates": [
+                [
+                  [
+                    9.476989243125104,
+                    47.48067255204134
+                  ],
+                  [
+                    8.536024138082581,
+                    47.36586953083
+                  ],
+                  [
+                    7.229985139825061,
+                    47.13551220276787
+                  ],
+                  [
+                    6.119337802724459,
+                    46.182699028304654
+                  ],
+                  [
+                    6.926613876449522,
+                    46.41361480319924
+                  ],
+                  [
+                    8.07839630011074,
+                    46.7458325561617
+                  ],
+                  [
+                    9.333016440167455,
+                    47.111021589561204
+                  ],
+                  [
+                    9.476989243125104,
+                    47.48067255204134
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            }
+          }
+        ]
+      },
+      visible: true,
+      bbox: [6.121699327190461, 46.05823590807236, 9.496699327190466, 47.5945721328394],
+      nativeBbox: {
+        epsg: 'EPSG:21781',
+        bbox: [495592.4002543411, 97816.18720803942, 758272.4757513476, 272596.3306093862]
+      }
+    });
+
+    if (!this.layersSvc.getLayerById(vectorLayerSwiss.id)) {
+      this.layersSvc.addLayer(vectorLayerSwiss, 'Layers');
+    }
   }
 
 }

--- a/projects/demo-maps/src/app/route-components/route-example-threejs/route-example-threejs.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-threejs/route-example-threejs.component.ts
@@ -84,8 +84,7 @@ export class RouteMap8Component implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    // this.mapOlSvc.setProjection(EPSG_4326_Def);
-    this.mapStateSvc.setProjection(EPSG_4326_Def.code);
+    this.mapStateSvc.setProjection(EPSG_4326_Def);
     this.mapOlSvc.map.getView().setMaxZoom(4); // zooming in deeper causes too much noise on the image-edges.
   }
 

--- a/projects/demo-maps/src/app/route-components/route-example-threejs/route-example-threejs.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-threejs/route-example-threejs.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, HostBinding, AfterViewInit } from '@angular/core';
 
 import { LayersService, CustomLayer } from '@dlr-eoc/services-layers';
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { MapStateService, EPSG_4326_Def } from '@dlr-eoc/services-map-state';
 import { MapOlService, IMapControls } from '@dlr-eoc/map-ol';
 import { MapThreeService } from '@dlr-eoc/map-three';
 
@@ -84,8 +84,8 @@ export class RouteMap8Component implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    const projection = getProjection('EPSG:4326');
-    this.mapOlSvc.setProjection(projection);
+    // this.mapOlSvc.setProjection(EPSG_4326_Def);
+    this.mapStateSvc.setProjection(EPSG_4326_Def.code);
     this.mapOlSvc.map.getView().setMaxZoom(4); // zooming in deeper causes too much noise on the image-edges.
   }
 

--- a/projects/map-cesium/karma.conf.js
+++ b/projects/map-cesium/karma.conf.js
@@ -57,7 +57,16 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    // https://github.com/karma-runner/karma-chrome-launcher/issues/263
+    // https://github.com/geosolutions-it/MapStore2/issues/10042
+    // https://github.com/google/model-viewer/issues/4972
+    browsers: ['Chrome', 'HeadlessChrome'],
+    customLaunchers:{
+      HeadlessChrome:{
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--enable-gpu', '--use-gl=angle']
+      }
+    },
     singleRun: false,
     restartOnFileChange: true
   });

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-cesium",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,15 +19,15 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
     "@cesium/engine": "^22.3.0",
     "@cesium/widgets": "^14.3.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8"
   },
   "sideEffects": false
 }

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-cesium",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,15 +19,15 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
     "@cesium/engine": "^22.3.0",
     "@cesium/widgets": "^14.3.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7"
   },
   "sideEffects": false
 }

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-cesium",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,15 +19,15 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
     "@cesium/engine": "^22.3.0",
     "@cesium/widgets": "^14.3.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6"
   },
   "sideEffects": false
 }

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -104,7 +104,7 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
       this.viewer.imageryLayers.removeAll();
       this.viewer.dataSources.removeAll();
       this.viewer.scene.primitives.removeAll();
-      //this.viewer.scene.primitives.destroy(); -> will lead to developer errors due to missing elements
+      this.viewer.destroy();
     }
     this.mapSvc.destroyLayerGrpoups();
   }

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -104,7 +104,7 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
       this.viewer.imageryLayers.removeAll();
       this.viewer.dataSources.removeAll();
       this.viewer.scene.primitives.removeAll();
-      this.viewer.scene.primitives.destroy();
+      //this.viewer.scene.primitives.destroy(); -> will lead to developer errors due to missing elements
     }
     this.mapSvc.destroyLayerGrpoups();
   }

--- a/projects/map-cesium/src/lib/map-cesium.component.ts
+++ b/projects/map-cesium/src/lib/map-cesium.component.ts
@@ -181,9 +181,11 @@ export class MapCesiumComponent implements OnInit, AfterViewInit, OnDestroy {
     const zoom = this.mapSvc.getZoom();
     const newCenter = this.mapSvc.getCenter();
     const extent = this.mapSvc.getCurrentExtent();
+    const nativeExtent = extent; // there is no projection extent?
+    const epsg = this.mapSvc.EPSG;
     const viewAngle = this.mapSvc.getViewAngle();
     const rotation = this.mapSvc.getRotation();
-    return new MapState(zoom, newCenter, { notifier }, extent, time, viewAngle, rotation);
+    return new MapState(zoom, newCenter, { notifier }, extent, nativeExtent, time, viewAngle, rotation, epsg);
   }
 
   private subscribeToMapEvents() {

--- a/projects/map-cesium/src/lib/map-cesium.service.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.spec.ts
@@ -7,9 +7,8 @@ import { ImageryLayer, Scene } from '@cesium/engine';
 import { CustomLayer, ILayerOptions, IRasterLayerOptions, Layer, RasterLayer, VectorLayer, WmsLayer, WmtsLayer } from '@dlr-eoc/services-layers';
 
 import testFeatureCollection from '@dlr-eoc/shared-assets/geojson/testFeatureCollection.json';
+import { WebMercator } from '@dlr-eoc/services-map-state';
 
-const WebMercator = 'EPSG:3857';
-const WGS84 = 'EPSG:4326';
 
 let mapTarget: { size: number[], container: HTMLDivElement };
 

--- a/projects/map-cesium/src/lib/map-cesium.service.spec.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.spec.ts
@@ -225,11 +225,11 @@ describe('MapCesiumService State', () => {
 
   it('should set/get extent', () => {
     service.createMap(mapTarget.container);
-    const oldExtent = service.getCurrentExtent(true);
+    const oldExtent = service.getCurrentExtent();
     const extent = [-14, 33, 40, 57] as any;
 
     service.setExtent(extent);
-    expect(service.getCurrentExtent(true) !== oldExtent).toBeTrue();
+    expect(service.getCurrentExtent() !== oldExtent).toBeTrue();
   });
 
   it('should set/get rotation', async () => {

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -221,7 +221,7 @@ export class MapCesiumService {
   }
 
 
-  public getCurrentExtent(geographic?: boolean): TGeoExtent {
+  public getCurrentExtent(): TGeoExtent {
     let extent!: TGeoExtent;
     // https://cesium.com/learn/cesiumjs/ref-doc/Rectangle.html
     const currentRectangle = this.viewer.camera.computeViewRectangle();

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -4,11 +4,9 @@ import { Layer, VectorLayer, CustomLayer, RasterLayer, WmtsLayer, WmsLayer, TGeo
 import { ICesiumControls } from './map-cesium.component';
 import { Cartesian3, Cesium3DTileStyle, Cesium3DTileset, CesiumTerrainProvider, Color, Credit, DataSource, EllipsoidTerrainProvider, GeoJsonDataSource, I3SDataProvider, ImageryLayer, Ion, JulianDate, KmlDataSource, Rectangle, TileMapServiceImageryProvider, TimeIntervalCollection, UrlTemplateImageryProvider, WebMapServiceImageryProvider, WebMapTileServiceImageryProvider, WebMercatorTilingScheme, Math as CesiumMath, BillboardGraphics} from '@cesium/engine';
 import { Viewer } from '@cesium/widgets';
-import { IMapCenter } from '@dlr-eoc/services-map-state';
+import { IMapCenter, WebMercator } from '@dlr-eoc/services-map-state';
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes
-const WebMercator = 'EPSG:3857';
-const WGS84 = 'EPSG:4326';
 
 @Injectable({
   providedIn: 'root'

--- a/projects/map-maplibre/karma.conf.js
+++ b/projects/map-maplibre/karma.conf.js
@@ -46,7 +46,16 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    // https://github.com/karma-runner/karma-chrome-launcher/issues/263
+    // https://github.com/geosolutions-it/MapStore2/issues/10042
+    // https://github.com/google/model-viewer/issues/4972
+    browsers: ['Chrome', 'HeadlessChrome'],
+    customLaunchers:{
+      HeadlessChrome:{
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--enable-gpu', '--use-gl=angle']
+      }
+    },
     singleRun: false,
     restartOnFileChange: true
   });

--- a/projects/map-maplibre/package.json
+++ b/projects/map-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-maplibre",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,13 +21,13 @@
     "tslib": "^2.6.3",
     "maplibre-gl": "^5.5.0",
     "@mapbox/togeojson": "0.16.2",
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
-    "@dlr-eoc/utilities": "16.0.0-next.5"
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/utilities": "16.0.0-next.6"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6"
   },
   "sideEffects": false
 }

--- a/projects/map-maplibre/package.json
+++ b/projects/map-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-maplibre",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,13 +21,13 @@
     "tslib": "^2.6.3",
     "maplibre-gl": "^5.5.0",
     "@mapbox/togeojson": "0.16.2",
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
-    "@dlr-eoc/utilities": "16.0.0-next.6"
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/utilities": "16.0.0-next.7"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7"
   },
   "sideEffects": false
 }

--- a/projects/map-maplibre/package.json
+++ b/projects/map-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-maplibre",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,13 +21,13 @@
     "tslib": "^2.6.3",
     "maplibre-gl": "^5.5.0",
     "@mapbox/togeojson": "0.16.2",
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
-    "@dlr-eoc/utilities": "16.0.0-next.7"
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
+    "@dlr-eoc/utilities": "16.0.0-next.8"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8"
   },
   "sideEffects": false
 }

--- a/projects/map-maplibre/src/lib/map-maplibre.component.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.ts
@@ -2,7 +2,7 @@ import { AfterViewChecked, AfterViewInit, Component, ElementRef, Input, NgZone, 
 import { Map as glMap, MapLibreEvent, NavigationControl, ScaleControl, StyleSpecification, StyleLayer, GeoJSONSource, Evented, addSourceType } from 'maplibre-gl';
 import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, changeOrderOfLayers, setRotation, setPitch, getRotation, getUkisLayerMetadata, UKIS_METADATA } from './maplibre.helpers';
 
-import { MapState, MapStateService } from '@dlr-eoc/services-map-state';
+import { MapState, MapStateService, WebMercator, WGS84 } from '@dlr-eoc/services-map-state';
 import { LayersService, TFiltertypes, TFiltertypesUncap, Layer as ukisLayer } from '@dlr-eoc/services-layers';
 
 
@@ -237,11 +237,22 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
     const zoom = this.map.getZoom();
     const latLng = this.map.getCenter();
     const extent = getExtent(this.map, true);
+    const nativeExtent = getExtent(this.map, false);
     const viewAngle = this.map.getPitch();
     const rotation = getRotation(this.map);
+    // https://maplibre.org/maplibre-style-spec/projection/
+    const projectionSpecType = this.map.getProjection()?.type;
+    const projMapping = { globe: WGS84, mercator: WebMercator };
+    let epsg = projMapping.mercator;
+    if(Array.isArray(projectionSpecType)){
+      // TODO: Perhaps this won't work in all cases.
+      epsg = projectionSpecType.pop() as string;
+    }else if(typeof projectionSpecType === 'string'){
+      epsg = projMapping[projectionSpecType];
+    }
 
     const newCenter = { lat: latLng.lat, lon: latLng.lng };
-    const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time, viewAngle, rotation);
+    const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, nativeExtent, oldMapState.time, viewAngle, rotation, epsg);
     this.mapStateSvc.setMapState(ms);
   };
 

--- a/projects/map-maplibre/src/lib/map-maplibre.service.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.service.ts
@@ -6,6 +6,7 @@ import { Map as glMap, StyleSpecification, StyleLayer } from 'maplibre-gl';
 import { BehaviorSubject } from 'rxjs';
 import { LayerSourceSpecification, UKIS_METADATA } from './maplibre.helpers';
 import { createLayer, layerIsSupported, updateSource, updateStyleLayerProperties } from './maplibre-layers.helpers';
+import { WebMercator, WGS84 } from '@dlr-eoc/services-map-state';
 
 type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes;
 
@@ -17,8 +18,8 @@ export class MapMaplibreService {
   readonly FILTER_TYPE_KEY = 'filtertype' as const;
   readonly ID_KEY = 'id' as const;
   readonly TITLE_KEY = 'title' as const;
-  WebMercator = 'EPSG:3857';
-  WGS84 = 'EPSG:4326';
+  WebMercator = WebMercator
+  WGS84 = WGS84
 
   public map = new BehaviorSubject<glMap | null>(null);
   constructor() { }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-ol",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -17,9 +17,9 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
-    "@dlr-eoc/utils-maps": "16.0.0-next.7",
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
+    "@dlr-eoc/utils-maps": "16.0.0-next.8",
     "ol": "^v10.8.0",
     "ol-mapbox-style": "^13.2.1",
     "proj4": "^2.17.0",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8"
   }
 }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-ol",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -17,9 +17,9 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
-    "@dlr-eoc/utils-maps": "16.0.0-next.6",
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/utils-maps": "16.0.0-next.7",
     "ol": "^v10.8.0",
     "ol-mapbox-style": "^13.2.1",
     "proj4": "^2.17.0",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7"
   }
 }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-ol",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -17,9 +17,9 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
-    "@dlr-eoc/utils-maps": "16.0.0-next.5",
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/utils-maps": "16.0.0-next.6",
     "ol": "^v10.8.0",
     "ol-mapbox-style": "^13.2.1",
     "proj4": "^2.17.0",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5"
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6"
   }
 }

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit, ViewEncapsulation, Input, OnDestroy, AfterViewChecked, AfterViewInit, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, Input, OnDestroy, AfterViewChecked, AfterViewInit, ViewChild, ElementRef, NgZone, effect, signal } from '@angular/core';
 
 
 
 
-import { MapState } from '@dlr-eoc/services-map-state';
+import { IMapStateProjection, MapState } from '@dlr-eoc/services-map-state';
 import { MapStateService } from '@dlr-eoc/services-map-state';
 import { Subscription } from 'rxjs';
 import { skip } from 'rxjs/operators';
@@ -89,9 +89,10 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
 
   /** [width, height] */
   private mapSize = [0, 0];
-  private initialMapStateSet = false;
+  private initialMapStateSet = signal(false);
 
   constructor(private mapSvc: MapOlService, private ngZone: NgZone) {
+    this.subscribeToMapStateRegisterProjection();
   }
   ngOnInit() {
     /** Subscribe to mapStateSvc before map is created */
@@ -99,6 +100,8 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
     this.initMap();
     /** subscribe to layers oninit so they get pulled after view init */
     this.subscribeToLayers();
+    // TODO: refactor to signals
+    this.subscribeToMapStateSetProjection();
   }
 
   /**
@@ -156,7 +159,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
     const mapDiv = this.getMapDiv();
     if (mapDiv) {
       if (mapDiv.width === this.mapSize[0] && mapDiv.height === this.mapSize[1]) {
-        if (!this.initialMapStateSet) {
+        if (!this.initialMapStateSet()) {
           /**
            * If container size and map size are equal (map size 'stable')
            * Get last state from mapStateSvc and set it, so a User can set the initial MapState in a component on ngOnInit
@@ -164,7 +167,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
            */
           const oldMapState = this.mapStateSvc.getMapState().getValue();
           this.setMapState(oldMapState);
-          this.initialMapStateSet = true;
+          this.initialMapStateSet.set(true);
         }
       } else {
         /** update map size till container size and map size are equal */
@@ -474,19 +477,35 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
         this.mapSvc.setRotation(mapState.rotation);
       } else if (lastAction === 'setRotation') {
         this.mapSvc.setRotation(mapState.rotation);
-      } else if (lastAction === 'setProjection') {
-        const projIsReg = this.mapSvc.registeredProjections.has(mapState.epsg);
-        const proj = this.mapSvc.getProjection().getCode();
-        if (projIsReg && mapState.epsg !== proj) {
-          this.mapSvc.setProjection(mapState.epsg, mapState.projOptions);
-        } else {
-          console.info(`projection: ${mapState.epsg} is not registered. Register them first with this.mapSvc.registerProjection.`)
-        }
       }
     }
     /* else if (mapState.options.notifier === 'map') {
       console.log("--------Map triggered mapState change", mapState);
     } */
+  }
+
+  private setMapStateProjection(item: IMapStateProjection) {
+    const lastAction = this.mapStateSvc.getLastAction().getValue();
+    if (lastAction === 'setProjection') {
+      let projIsReg = this.mapSvc.registeredProjections.has(item.epsg);
+      const mapStateProjection = this.mapStateSvc.registeredProjections();
+      const isInStateSvc = mapStateProjection.find(p => p.code === item.epsg);
+      if (!projIsReg && isInStateSvc) {
+        this.mapSvc.registerProjection(isInStateSvc);
+        projIsReg = this.mapSvc.registeredProjections.has(item.epsg);
+      }
+
+      if (!projIsReg) {
+        console.info(`Projection ${item} is not registered in mapSvc`, this.mapSvc.registeredProjections, 'MapState:',this.mapStateSvc.registeredProjections());
+      }
+
+      const proj = this.mapSvc.getProjection().getCode();
+      if (projIsReg && item.epsg !== proj) {
+        this.mapSvc.setProjection(item.epsg, item.projOptions);
+      } else {
+        console.info(`projection: ${item.epsg} is not registered. Register them first with this.mapSvc.registerProjection.`)
+      }
+    }
   }
 
   private subscribeToMapState() {
@@ -495,6 +514,25 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       const mapStateOn = this.mapStateSvc.getMapState().pipe(skip(1)).subscribe(state => this.setMapState(state));
       this.subs.push(mapStateOn);
     }
+  }
+
+  private subscribeToMapStateSetProjection() {
+    if (this.mapStateSvc) {
+      const mapStateOn = this.mapStateSvc.getProjection().subscribe(item => this.setMapStateProjection(item));
+      this.subs.push(mapStateOn);
+    }
+  }
+
+  private subscribeToMapStateRegisterProjection(){
+    effect(() => {
+      const registeredProjections = this.mapStateSvc.registeredProjections();
+      registeredProjections.forEach(p => {
+        const hasProj = this.mapSvc.registeredProjections.has(p.code);
+        if (!hasProj) {
+          this.mapSvc.registerProjection(p);
+        }
+      });
+    });
   }
 
   private subscribeToMapEvents() {

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -466,12 +466,22 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
     if (mapState.options.notifier === 'user') {
       if (lastAction === 'setExtent') {
         this.mapSvc.setExtent(mapState.extent, true);
+      } else if (lastAction === 'setNativeExtent') {
+        this.mapSvc.setExtent(mapState.nativeExtent, false);
       } else if (lastAction === 'setState') {
         this.mapSvc.setZoom(mapState.zoom);
         this.mapSvc.setCenter([mapState.center.lon, mapState.center.lat], true);
         this.mapSvc.setRotation(mapState.rotation);
       } else if (lastAction === 'setRotation') {
         this.mapSvc.setRotation(mapState.rotation);
+      } else if (lastAction === 'setProjection') {
+        const projIsReg = this.mapSvc.registeredProjections.has(mapState.epsg);
+        const proj = this.mapSvc.getProjection().getCode();
+        if (projIsReg && mapState.epsg !== proj) {
+          this.mapSvc.setProjection(mapState.epsg, mapState.projOptions);
+        } else {
+          console.info(`projection: ${mapState.epsg} is not registered. Register them first with this.mapSvc.registerProjection.`)
+        }
       }
     }
     /* else if (mapState.options.notifier === 'map') {
@@ -493,10 +503,12 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       const zoom = this.mapSvc.getZoom();
       const center = this.mapSvc.getCenter(true);
       const extent = this.mapSvc.getCurrentExtent(true);
+      const nativeExtent = this.mapSvc.getCurrentExtent(false);
       const rotation = this.mapSvc.getRotation();
+      const epsg = this.mapSvc.getProjection().getCode();
 
       const newCenter = { lat: parseFloat(center[1]), lon: parseFloat(center[0]) };
-      const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, oldMapState.time, oldMapState.viewAngle, rotation);
+      const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, nativeExtent, oldMapState.time, oldMapState.viewAngle, rotation, epsg);
       this.mapStateSvc.setMapState(ms);
     };
     this.map.on('moveend', this.mapOnMoveend);

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -496,16 +496,35 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       }
 
       if (!projIsReg) {
-        console.info(`Projection ${item} is not registered in mapSvc`, this.mapSvc.registeredProjections, 'MapState:',this.mapStateSvc.registeredProjections());
+        console.info(`Projection ${item} is not registered in mapSvc`, this.mapSvc.registeredProjections, 'MapState:', this.mapStateSvc.registeredProjections());
       }
 
       const proj = this.mapSvc.getProjection().getCode();
       if (projIsReg && item.epsg !== proj) {
         this.mapSvc.setProjection(item.epsg, item.fitOptions);
+        // Update the layers to use the correct layer extent - otherwise layers may not be displayed
+        this.updateLayersAfterProjection();
       } else {
         console.info(`projection: ${item.epsg} is not registered. Register them first with this.mapSvc.registerProjection.`)
       }
     }
+  }
+
+  private updateLayersAfterProjection() {
+    const layerGroupCollection = this.mapSvc.getLayerGroups();
+    layerGroupCollection.forEach(lg => {
+      const layers = lg.getLayers();
+      layers.forEach(l => {
+        const id = l.get('id');
+        const ukisLayer = this.layersSvc.getLayerOrGroupById(id);
+
+        if (ukisLayer instanceof Layer) {
+          this.layersSvc.updateLayer(ukisLayer);
+        } else {
+          this.layersSvc.updateLayerGroup(ukisLayer);
+        }
+      });
+    });
   }
 
   private subscribeToMapState() {
@@ -523,7 +542,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
     }
   }
 
-  private subscribeToMapStateRegisterProjection(){
+  private subscribeToMapStateRegisterProjection() {
     effect(() => {
       const registeredProjections = this.mapStateSvc.registeredProjections();
       registeredProjections.forEach(p => {

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -501,7 +501,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
 
       const proj = this.mapSvc.getProjection().getCode();
       if (projIsReg && item.epsg !== proj) {
-        this.mapSvc.setProjection(item.epsg, item.projOptions);
+        this.mapSvc.setProjection(item.epsg, item.fitOptions);
       } else {
         console.info(`projection: ${item.epsg} is not registered. Register them first with this.mapSvc.registerProjection.`)
       }

--- a/projects/map-ol/src/lib/map-ol.service.spec.ts
+++ b/projects/map-ol/src/lib/map-ol.service.spec.ts
@@ -44,10 +44,8 @@ import olMapBrowserEvent from 'ol/MapBrowserEvent';
 
 import { Fill as olFill, Stroke as olStroke, Style as olStyle } from 'ol/style';
 import { CommonModule } from '@angular/common';
+import { EPSG_3031_Def, EPSG_4326_Def, WebMercator, WGS84 } from '@dlr-eoc/services-map-state';
 
-
-const WebMercator = 'EPSG:3857';
-const WGS84 = 'EPSG:4326';
 
 let mapTarget: { size: number[], container: HTMLDivElement };
 
@@ -1647,8 +1645,8 @@ describe('MapOlService State', () => {
   it('should set/get projection obj', () => {
     const service: MapOlService = TestBed.inject(MapOlService);
     service.createMap(mapTarget.container);
-    const projection = getProjection(WGS84);
-    service.setProjection(projection);
+    const projection = service.getOlProjection(EPSG_4326_Def);
+    service.setProjection(projection.getCode());
     expect(service.getProjection()).toBe(projection);
   });
 
@@ -1666,8 +1664,8 @@ describe('MapOlService State', () => {
     // Test for Point Feature
     expect((testFeatureBefore.getGeometry() as olPoint).getCoordinates()).toEqual(pointCoordinates);
 
-    const projection = getProjection(WGS84);
-    service.setProjection(projection);
+    const projection = service.getOlProjection(EPSG_4326_Def);
+    service.setProjection(projection.getCode());
 
     const reprojectedLayer = service.getLayerByKey({ key: 'id', value: 'ID-vector' }, 'layers');
     const testFeature = (reprojectedLayer as olVectorLayer<olVectorSource>).getSource().getFeatures()[3];
@@ -1679,16 +1677,12 @@ describe('MapOlService State', () => {
   it('should register a proj4 projection on Openlayers', () => {
     const service: MapOlService = TestBed.inject(MapOlService);
     service.createMap(mapTarget.container);
-    const antarcticPolarStereographic = {
-      code: `EPSG:3031`,
-      proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs'
-    };
-    const proj = getProjection(antarcticPolarStereographic.code);
+    const proj = service.getOlProjection(EPSG_3031_Def)
     expect(proj).toBe(null);
 
-    service.registerProjection(antarcticPolarStereographic);
-    const projAfter = getProjection(antarcticPolarStereographic.code);
-    expect(projAfter.getCode()).toBe(antarcticPolarStereographic.code);
+    service.registerProjection(EPSG_3031_Def);
+    const projAfter = getProjection(EPSG_3031_Def.code);
+    expect(projAfter.getCode()).toBe(EPSG_3031_Def.code);
   });
 
   it('should create a Openlayers projection', () => {

--- a/projects/map-ol/src/lib/map-ol.service.spec.ts
+++ b/projects/map-ol/src/lib/map-ol.service.spec.ts
@@ -1633,10 +1633,10 @@ describe('MapOlService State', () => {
     service.createMap(mapTarget.container);
     let newProj = null;
     const projectionChange = service.projectionChange.subscribe(projLike => {
-      newProj = projLike.getCode();
+      newProj = projLike?.getCode();
     });
-    const projectionCode = WGS84;
-    service.setProjection(projectionCode);
+    const projectionCode = EPSG_4326_Def.code;
+    service.setProjection(EPSG_4326_Def);
     expect(service.getProjection().getCode()).toBe(projectionCode);
     expect(newProj).toBe(projectionCode);
     projectionChange.unsubscribe();
@@ -1646,8 +1646,8 @@ describe('MapOlService State', () => {
     const service: MapOlService = TestBed.inject(MapOlService);
     service.createMap(mapTarget.container);
     const projection = service.getOlProjection(EPSG_4326_Def);
-    service.setProjection(projection.getCode());
-    expect(service.getProjection()).toBe(projection);
+    service.setProjection(EPSG_4326_Def);
+    expect(service.getProjection().getCode()).toBe(projection.getCode());
   });
 
   it('should update vectors to the correct new projection', () => {
@@ -1664,8 +1664,7 @@ describe('MapOlService State', () => {
     // Test for Point Feature
     expect((testFeatureBefore.getGeometry() as olPoint).getCoordinates()).toEqual(pointCoordinates);
 
-    const projection = service.getOlProjection(EPSG_4326_Def);
-    service.setProjection(projection.getCode());
+    service.setProjection(EPSG_4326_Def);
 
     const reprojectedLayer = service.getLayerByKey({ key: 'id', value: 'ID-vector' }, 'layers');
     const testFeature = (reprojectedLayer as olVectorLayer<olVectorSource>).getSource().getFeatures()[3];
@@ -1677,7 +1676,9 @@ describe('MapOlService State', () => {
   it('should register a proj4 projection on Openlayers', () => {
     const service: MapOlService = TestBed.inject(MapOlService);
     service.createMap(mapTarget.container);
-    const proj = service.getOlProjection(EPSG_3031_Def)
+    const hasProj = service.registeredProjections.has(EPSG_3031_Def.code);
+    const proj = getProjection(EPSG_3031_Def.code)
+    expect(hasProj).toBeFalse();
     expect(proj).toBe(null);
 
     service.registerProjection(EPSG_3031_Def);

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -89,7 +89,7 @@ import { Subject } from 'rxjs';
 import { flattenLayers, layerOrGroupSetZIndex } from '@dlr-eoc/utils-maps';
 import LayerRenderer from 'ol/renderer/Layer';
 import VectorSource from 'ol/source/Vector';
-import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjOptions } from '@dlr-eoc/services-map-state';
+import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjFitOptions } from '@dlr-eoc/services-map-state';
 
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes;
@@ -2523,7 +2523,7 @@ export class MapOlService {
    * see: https://openlayers.org/en/latest/apidoc/module-ol_source_Source.html#projection
    * projection is proj~ProjectionLike
    */
-  public setProjection(projection: IProjDef | IProjDef['code'], options?: IProjOptions) {
+  public setProjection(projection: IProjDef | IProjDef['code'], options?: IProjFitOptions) {
     let projIsReg = this.registeredProjections.get((typeof projection === 'string') ? projection : projection.code);
     
     // IProjDef is used and it is not registered, register it and use it.

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -134,7 +134,12 @@ export class MapOlService {
     private envInjector: EnvironmentInjector
   ) {
     this.map = new olMap({ controls: [] });
-    this.view = new olView();
+    this.view = new olView({
+      center: [0, 0],
+      zoom: 0,
+      projection: WebMercator
+    });
+    this.map.setView(this.view);
     this.EPSG = WebMercator;
   }
 

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -69,7 +69,7 @@ import { Options as olProjectionOptions } from 'ol/proj/Projection';
 import { transformExtent, get as getProjection, transform } from 'ol/proj';
 import { register as olRegister } from 'ol/proj/proj4';
 import proj4 from 'proj4';
-import { extend as olExtend, getWidth as olGetWidth, getHeight as olGetHeight, getTopLeft as olGetTopLeft, containsCoordinate as olContainsCoordinate, getCenter as olExtGetCenter, applyTransform, containsExtent } from 'ol/extent';
+import { extend as olExtend, getWidth as olGetWidth, getHeight as olGetHeight, getTopLeft as olGetTopLeft, containsCoordinate as olContainsCoordinate, getCenter as olExtGetCenter, containsExtent, Extent as olExtent } from 'ol/extent';
 import { DEFAULT_MAX_ZOOM, DEFAULT_TILE_SIZE } from 'ol/tilegrid/common';
 import { easeOut } from 'ol/easing.js';
 
@@ -89,6 +89,7 @@ import { Subject } from 'rxjs';
 import { flattenLayers, layerOrGroupSetZIndex } from '@dlr-eoc/utils-maps';
 import LayerRenderer from 'ol/renderer/Layer';
 import VectorSource from 'ol/source/Vector';
+import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjOptions } from '@dlr-eoc/services-map-state';
 
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes;
@@ -119,6 +120,8 @@ export class MapOlService {
   private hitLayerPrev = null;
   /** 'olProjection' */
   public projectionChange = new Subject<olProjection>();
+  public registeredProjections: Map<IProjDef['code'], IProjDef> = new Map();
+
   /**
    * This object keeps track of currently bound angular-components that are being used as popups.
    * We keep a reference to them here so that we can remove them again after they are no longer displayed.
@@ -251,7 +254,11 @@ export class MapOlService {
     this.map.setView(tempview);
     // this.map.getControls().clear();
     this.view = this.map.getView();
-    this.setProjection(this.EPSG);
+    // Register projection at startup if it is not identical
+    if (this.view.getProjection().getCode() !== this.EPSG) {
+      this.registerProjection(EPSG_3857_Def);
+      this.setProjection(this.EPSG);
+    }
     if (target) {
       this.map.setTarget(target);
     }
@@ -2514,8 +2521,16 @@ export class MapOlService {
    * see: https://openlayers.org/en/latest/apidoc/module-ol_source_Source.html#projection
    * projection is proj~ProjectionLike
    */
-  public setProjection(projection: olProjection | string, fitToProjectionExtent: boolean = false) {
-    if (projection) {
+  public setProjection(projection: IProjDef | string, options?: IProjOptions) {
+    let projIsReg = this.registeredProjections.get((typeof projection === 'string') ? projection : projection.code);
+    
+    // IProjDef is used and it is not registered, register it and use it.
+    if(typeof projection !== 'string' && !projIsReg){
+      this.registerProjection(projection);
+      projIsReg = this.registeredProjections.get(projection.code);
+    }
+
+    if (projIsReg) {
       let viewOptions: olViewOptions = {};
       if (this.viewOptions) {
         viewOptions = this.viewOptions;
@@ -2528,17 +2543,11 @@ export class MapOlService {
       const oldProj = oldView.getProjection();
       const oldExtent = oldView.calculateExtent();
 
-      let newProjection: olProjection;
-      if (projection instanceof olProjection) {
-        newProjection = projection;
-      } else if (typeof projection === 'string') {
-        newProjection = getProjection(projection);
-      }
-
+      const newProjection = this.getOlProjection(projIsReg);
       if (newProjection) {
         viewOptions.projection = newProjection;
         viewOptions.extent = newProjection.getExtent();
-        viewOptions.center = olExtGetCenter(viewOptions.extent);
+        viewOptions.center = (viewOptions.extent) ? olExtGetCenter(viewOptions.extent) : viewOptions.center;
 
         // https://openlayers.org/en/latest/examples/reprojection-by-code.html
         const view = new olView(viewOptions);
@@ -2548,11 +2557,21 @@ export class MapOlService {
         this.view = this.map.getView();
 
 
-        if (fitToProjectionExtent) {
+        if (options?.fitToProjectionExtent) {
           this.view.fit(viewOptions.extent);
         } else {
-          // Try zooming to the old bbox if that works in the new projection.
-          const newExtent = transformExtent(oldExtent, oldProj, newProjection, 8);
+          let newExtent: olExtent;
+          if (options?.fitToBbox) {
+            // Try zooming to a bbox provided in set projection.
+            newExtent = transformExtent(options.fitToBbox, WGS84, newProjection, 8);
+          } else if (options?.fitToNativeBbox) {
+            // the bbox is in the newProjection;
+            newExtent = options.fitToNativeBbox;
+          } else {
+            // Try zooming to the old bbox if that works in the new projection.
+            newExtent = transformExtent(oldExtent, oldProj, newProjection, 8);
+          }
+
           if (containsExtent(viewOptions.extent, newExtent)) {
             this.view.fit(newExtent);
           } else {
@@ -2581,7 +2600,7 @@ export class MapOlService {
         console.log(`projection ${projection} is invalid or not registered!`);
       }
     } else {
-      // console.log('projection code is undefined');
+      console.log('projection code is undefined or not registered', projection, this.registeredProjections);
     }
   }
 
@@ -2589,15 +2608,19 @@ export class MapOlService {
    * @param projDef.code - e.g.: "EPSG:4326"
    * @param projDef.proj4js - e.g.: "+title=WGS 84 (long/lat) +proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees"
    */
-  public registerProjection(projDef: { code: string, proj4js: string }) {
-    proj4.defs(projDef.code, projDef.proj4js);
-    olRegister(proj4);
+  public registerProjection(projDef: IProjDef) {
+    const hasProj = this.registeredProjections.has(projDef.code);
+    if (!hasProj) {
+      proj4.defs(projDef.code, projDef.proj4js);
+      olRegister(proj4);
+      this.registeredProjections.set(projDef.code, projDef);
+    }
   }
 
   /**
-   * Returns a OpenLayers Projection from Options
+   * Returns a OpenLayers Projection froma Definition
    */
-  public getOlProjection(projDef: olProjectionOptions): olProjection {
+  public getOlProjection(projDef: IProjDef | olProjectionOptions): olProjection {
     return new olProjection({
       code: projDef.code,
       extent: projDef.extent ? projDef.extent : undefined,

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -2514,6 +2514,8 @@ export class MapOlService {
   }
 
   /**
+   * If possible use @dlr-eoc/services-map-state to setProjection - this should only be used internally!
+   * 
    * vector layers will be reprojected automatically
    * wms layers will be updated with corresponding proj def in the requests.
    * for other raster layers and for those wms layers which backend does not support target projection, please
@@ -2521,11 +2523,11 @@ export class MapOlService {
    * see: https://openlayers.org/en/latest/apidoc/module-ol_source_Source.html#projection
    * projection is proj~ProjectionLike
    */
-  public setProjection(projection: IProjDef | string, options?: IProjOptions) {
+  public setProjection(projection: IProjDef | IProjDef['code'], options?: IProjOptions) {
     let projIsReg = this.registeredProjections.get((typeof projection === 'string') ? projection : projection.code);
     
     // IProjDef is used and it is not registered, register it and use it.
-    if(typeof projection !== 'string' && !projIsReg){
+    if (typeof projection !== 'string' && !projIsReg) {
       this.registerProjection(projection);
       projIsReg = this.registeredProjections.get(projection.code);
     }
@@ -2543,61 +2545,63 @@ export class MapOlService {
       const oldProj = oldView.getProjection();
       const oldExtent = oldView.calculateExtent();
 
-      const newProjection = this.getOlProjection(projIsReg);
-      if (newProjection) {
-        viewOptions.projection = newProjection;
-        viewOptions.extent = newProjection.getExtent();
-        viewOptions.center = (viewOptions.extent) ? olExtGetCenter(viewOptions.extent) : viewOptions.center;
+      // Test is not same projection
+      if (projIsReg.code !== oldProj.getCode()) {
+        const newProjection = this.getOlProjection(projIsReg);
+        if (newProjection) {
+          viewOptions.projection = newProjection;
+          viewOptions.extent = newProjection.getExtent();
+          viewOptions.center = (viewOptions.extent) ? olExtGetCenter(viewOptions.extent) : viewOptions.center;
 
-        // https://openlayers.org/en/latest/examples/reprojection-by-code.html
-        const view = new olView(viewOptions);
-        const oldProjection = this.EPSG;
-        this.EPSG = view.getProjection().getCode();
-        this.map.setView(view);
-        this.view = this.map.getView();
+          // https://openlayers.org/en/latest/examples/reprojection-by-code.html
+          const view = new olView(viewOptions);
+          const oldProjection = this.EPSG;
+          this.EPSG = view.getProjection().getCode();
+          this.map.setView(view);
+          this.view = this.map.getView();
 
-
-        if (options?.fitToProjectionExtent) {
-          this.view.fit(viewOptions.extent);
-        } else {
-          let newExtent: olExtent;
-          if (options?.fitToBbox) {
-            // Try zooming to a bbox provided in set projection.
-            newExtent = transformExtent(options.fitToBbox, WGS84, newProjection, 8);
-          } else if (options?.fitToNativeBbox) {
-            // the bbox is in the newProjection;
-            newExtent = options.fitToNativeBbox;
-          } else {
-            // Try zooming to the old bbox if that works in the new projection.
-            newExtent = transformExtent(oldExtent, oldProj, newProjection, 8);
-          }
-
-          if (containsExtent(viewOptions.extent, newExtent)) {
-            this.view.fit(newExtent);
-          } else {
+          if (options?.fitToProjectionExtent) {
             this.view.fit(viewOptions.extent);
-          }
-        }
-
-        // reprojecting vector layers
-        this.map.getLayers().getArray().forEach((layerGroup: olLayerGroup) => {
-          layerGroup.getLayers().getArray().forEach(layer => {
-            if (layer instanceof olLayer) {
-              let source = layer.getSource();
-              // check for nested sources, e.g. cluster or cluster of clusters etc
-              while (source['source']) {
-                source = source['source'];
-              }
-              if (source instanceof olVectorSource) {
-                this.reprojectFeatures(source, oldProjection, this.EPSG);
-              }
+          } else {
+            let newExtent: olExtent;
+            if (options?.fitToBbox) {
+              // Try zooming to a bbox provided in set projection.
+              newExtent = transformExtent(options.fitToBbox, WGS84, newProjection, 8);
+            } else if (options?.fitToNativeBbox) {
+              // the bbox is in the newProjection;
+              newExtent = options.fitToNativeBbox;
+            } else {
+              // Try zooming to the old bbox if that works in the new projection.
+              newExtent = transformExtent(oldExtent, oldProj, newProjection, 8);
             }
-          });
-        });
 
-        this.projectionChange.next(this.getProjection());
-      } else {
-        console.log(`projection ${projection} is invalid or not registered!`);
+            if (containsExtent(viewOptions.extent, newExtent)) {
+              this.view.fit(newExtent);
+            } else {
+              this.view.fit(viewOptions.extent);
+            }
+          }
+
+          // reprojecting vector layers
+          this.map.getLayers().getArray().forEach((layerGroup: olLayerGroup) => {
+            layerGroup.getLayers().getArray().forEach(layer => {
+              if (layer instanceof olLayer) {
+                let source = layer.getSource();
+                // check for nested sources, e.g. cluster or cluster of clusters etc
+                while (source['source']) {
+                  source = source['source'];
+                }
+                if (source instanceof olVectorSource) {
+                  this.reprojectFeatures(source, oldProjection, this.EPSG);
+                }
+              }
+            });
+          });
+
+          this.projectionChange.next(this.getProjection());
+        } else {
+          console.log(`projection ${projection} is invalid or not registered!`);
+        }
       }
     } else {
       console.log('projection code is undefined or not registered', projection, this.registeredProjections);
@@ -2605,6 +2609,8 @@ export class MapOlService {
   }
 
   /**
+   * If possible use @dlr-eoc/services-map-state to registerProjection - this should only be used internally!
+   * 
    * @param projDef.code - e.g.: "EPSG:4326"
    * @param projDef.proj4js - e.g.: "+title=WGS 84 (long/lat) +proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees"
    */

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1,7 +1,12 @@
 import { Injectable, ApplicationRef, ComponentRef, createComponent, EnvironmentInjector } from '@angular/core';
 
 
-import { Layer, VectorLayer, CustomLayer, RasterLayer, popup, WmtsLayer, WmsLayer, TGeoExtent, ILayerOptions, StackedLayer, StackedLayertype, CustomLayertype, WfsLayertype, KmlLayertype, GeojsonLayertype, TmsLayertype, WmtsLayertype, WmsLayertype, XyzLayertype, IPopupParams, IAnyObject, TFiltertypesUncap, TFiltertypes, IPopupEvent } from '@dlr-eoc/services-layers';
+import {
+  Layer, VectorLayer, CustomLayer, RasterLayer, popup, WmtsLayer, WmsLayer, TGeoExtent,
+  ILayerOptions, StackedLayer, StackedLayertype, CustomLayertype, WfsLayertype, KmlLayertype,
+  GeojsonLayertype, TmsLayertype, WmtsLayertype, WmsLayertype, XyzLayertype, IPopupParams,
+  IAnyObject, TFiltertypesUncap, TFiltertypes, IPopupEvent
+} from '@dlr-eoc/services-layers';
 
 import olMap from 'ol/Map';
 import olView, { FitOptions as olFitOptions } from 'ol/View';
@@ -812,6 +817,7 @@ export class MapOlService {
     }
 
     // ------------------------------------------
+    const currentProjection = this.getProjection().getCode();
     const layeroptions: olLayerOptions<LayerOptionsSources> & ILayerOptions = {
       // className - if
       opacity: l.opacity || 1,
@@ -860,8 +866,12 @@ export class MapOlService {
       layeroptions.minZoom = l.minZoom;
     }
 
-    if (l.bbox) {
-      layeroptions.extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, this.getProjection().getCode());
+    if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
+      layeroptions.extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
+      layeroptions.bbox = l.bbox;
+    } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
+      layeroptions.extent = [...l.nativeBbox.bbox];
+      layeroptions.nativeBbox = l.nativeBbox;
     }
 
     return layeroptions;
@@ -893,6 +903,7 @@ export class MapOlService {
       useInterimTilesOnError: true
     };
     const newlayer = new olTileLayer(Object.assign(layeroptions, baseTileLayerOptions));
+    this.setLayerBboxes(l, newlayer);
     this.setSubdomains(l, newlayer);
     this.setCrossOrigin(l, newlayer);
     this.addEventsToLayer(l, newlayer, olsource);
@@ -932,6 +943,7 @@ export class MapOlService {
       };
 
       newlayer = new olVectorTileLayer(Object.assign(layeroptions, vectorTileLayerOptions));
+      this.setLayerBboxes(l, newlayer);
       this.setCrossOrigin(l, newlayer);
       this.addEventsToLayer(l, newlayer, olsource);
 
@@ -989,6 +1001,7 @@ export class MapOlService {
 
     const layeroptions = this.createOlLayerOptions(l, 'wms', olsource);
     const newlayer = new olTileLayer(Object.assign(layeroptions, baseTileLayerOptions));
+    this.setLayerBboxes(l, newlayer);
     this.setSubdomains(l, newlayer);
     this.addEventsToLayer(l, newlayer, olsource);
     return newlayer;
@@ -1013,6 +1026,7 @@ export class MapOlService {
 
     };
     const newlayer = new olImageLayer(Object.assign(layeroptions, baseImageLayerOptions));
+    this.setLayerBboxes(l, newlayer);
     this.addEventsToLayer(l, newlayer, olsource);
     return newlayer;
   }
@@ -1062,6 +1076,7 @@ export class MapOlService {
       const baseTileLayerOptions: olBaseTileLayerOptions<olTileSource> = {};
 
       const newlayer = new olTileLayer(Object.assign(layeroptions, baseTileLayerOptions));
+      this.setLayerBboxes(l, newlayer);
       this.setSubdomains(l, newlayer);
       this.setCrossOrigin(l, newlayer);
       this.addEventsToLayer(l, newlayer, olsource);
@@ -1109,6 +1124,7 @@ export class MapOlService {
     if (l.cluster) {
       this.setCluster(l, newlayer, olsource, {});
     }
+    this.setLayerBboxes(l, newlayer);
     this.setSubdomains(l, newlayer);
     this.setCrossOrigin(l, newlayer);
     this.addEventsToLayer(l, newlayer, olsource);
@@ -1151,6 +1167,7 @@ export class MapOlService {
     if (l.cluster) {
       this.setCluster(l, newlayer, olsource, {});
     }
+    this.setLayerBboxes(l, newlayer);
     this.setCrossOrigin(l, newlayer);
     this.addEventsToLayer(l, newlayer, olsource);
     return newlayer;
@@ -1195,6 +1212,7 @@ export class MapOlService {
     if (l.cluster) {
       this.setCluster(l, newlayer, olsource, {});
     }
+    this.setLayerBboxes(l, newlayer);
     this.setCrossOrigin(l, newlayer);
     this.addEventsToLayer(l, newlayer, layeroptions.source);
     return newlayer;
@@ -1257,6 +1275,18 @@ export class MapOlService {
     }
   }
 
+  /** 
+   * add bbox and nativeBbox to olLayer to use layer.setExtent later after reproject
+  */
+  private setLayerBboxes(l: Layer, layer: olLayer<olSource>): void {
+    if (l.nativeBbox) {
+      layer.set('nativeBbox', l.nativeBbox);
+    }
+    if (l.bbox) {
+      layer.set('bbox', l.bbox);
+    }
+  }
+
   /** use subdomains to setUrl/s on source */
   private setSubdomains(l: Layer, layer: olLayer<olSource>): void {
     if (l instanceof VectorLayer || l instanceof RasterLayer) {
@@ -1293,6 +1323,7 @@ export class MapOlService {
   private create_custom_layer(l: CustomLayer<olBaseLayer>) {
     if (l.custom_layer) {
       const layer = l.custom_layer;
+      const currentProjection = this.getProjection().getCode();
 
       if (layer instanceof olLayer) {
         const olsource = layer.getSource() as olSource;
@@ -1312,6 +1343,7 @@ export class MapOlService {
           // tslint:disable-next-line: no-string-literal
           olsource['wrapX_'] = false;
         }
+        this.setLayerBboxes(l, layer);
         this.setCrossOrigin(l, layer);
         this.addEventsToLayer(l, layer, olsource);
 
@@ -1332,6 +1364,7 @@ export class MapOlService {
             gl.set(ID_KEY, layerId);
           }
           if (gl instanceof olLayer) {
+            this.setLayerBboxes(l, gl);
             this.setCrossOrigin(l, gl);
             this.addEventsToLayer(l, gl, gl.getSource());
           }
@@ -1348,9 +1381,11 @@ export class MapOlService {
           }
 
           /** fix set bbox for layers in olLayerGroup not only for the group */
-          if (l.bbox) {
-            const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, this.getProjection().getCode());
+          if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
+            const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
             gl.setExtent(extent);
+          } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
+            gl.setExtent([...l.nativeBbox.bbox]);
           }
         });
       } else {
@@ -1392,9 +1427,11 @@ export class MapOlService {
         layer['className_'] = l.id;
       }
 
-      if (l.bbox) {
-        const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, this.getProjection().getCode());
+      if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
+        const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
         layer.setExtent(extent);
+      } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
+        layer.setExtent([...l.nativeBbox.bbox]);
       }
 
       layer.setProperties(layeroptions);
@@ -2530,7 +2567,7 @@ export class MapOlService {
    */
   public setProjection(projection: IProjDef | IProjDef['code'], options?: IProjFitOptions) {
     let projIsReg = this.registeredProjections.get((typeof projection === 'string') ? projection : projection.code);
-    
+
     // IProjDef is used and it is not registered, register it and use it.
     if (typeof projection !== 'string' && !projIsReg) {
       this.registerProjection(projection);
@@ -2548,6 +2585,7 @@ export class MapOlService {
       }
       const oldView = this.map.getView();
       const oldProj = oldView.getProjection();
+      const oldEPSG = oldProj.getCode();
       const oldExtent = oldView.calculateExtent();
 
       // Test is not same projection
@@ -2560,7 +2598,6 @@ export class MapOlService {
 
           // https://openlayers.org/en/latest/examples/reprojection-by-code.html
           const view = new olView(viewOptions);
-          const oldProjection = this.EPSG;
           this.EPSG = view.getProjection().getCode();
           this.map.setView(view);
           this.view = this.map.getView();
@@ -2587,22 +2624,7 @@ export class MapOlService {
             }
           }
 
-          // reprojecting vector layers
-          this.map.getLayers().getArray().forEach((layerGroup: olLayerGroup) => {
-            layerGroup.getLayers().getArray().forEach(layer => {
-              if (layer instanceof olLayer) {
-                let source = layer.getSource();
-                // check for nested sources, e.g. cluster or cluster of clusters etc
-                while (source['source']) {
-                  source = source['source'];
-                }
-                if (source instanceof olVectorSource) {
-                  this.reprojectFeatures(source, oldProjection, this.EPSG);
-                }
-              }
-            });
-          });
-
+          this.adjustLayersAfterProjection(oldEPSG, projIsReg);
           this.projectionChange.next(this.getProjection());
         } else {
           console.log(`projection ${projection} is invalid or not registered!`);
@@ -2611,6 +2633,55 @@ export class MapOlService {
     } else {
       console.log('projection code is undefined or not registered', projection, this.registeredProjections);
     }
+  }
+
+  /**
+   * reproject vector layers and set extent for all
+   */
+  private reprojectVectorLayers(layer: olLayer, oldEpsg: string, newEpsg: string) {
+    let source = layer.getSource();
+    // check for nested sources, e.g. cluster or cluster of clusters etc
+    while (source['source']) {
+      source = source['source'];
+    }
+    if (source instanceof olVectorSource) {
+      this.reprojectFeatures(source, oldEpsg, newEpsg);
+    }
+  }
+
+  /**
+   * set or calculate the new layer extent after reprojectFeatures
+   */
+  private setLayerExtentAfterProjection(layer: olLayer, newEpsg: string) {
+    const bbox: TGeoExtent = layer.get('bbox');
+    const nativeBbox: Layer['nativeBbox'] = layer.get('nativeBbox');
+    const newLayerExt = layer.getExtent();
+    if (bbox && nativeBbox?.epsg !== newEpsg) {
+      const newLExt = transformExtent(bbox.slice(0, 4) as [number, number, number, number], WGS84, newEpsg);
+      layer.setExtent(newLExt);
+    } else if (nativeBbox?.epsg === newEpsg) {
+      layer.setExtent(nativeBbox.bbox);
+    } else if (newLayerExt?.length) {
+      // if the layer has an extent specified but no bbox or nativeBbox has been defined
+      layer.setExtent(undefined);
+    }
+  }
+
+  /**
+   * reprojecting vector layers and set extent
+   */
+  private adjustLayersAfterProjection(oldEpsg: string, projection: IProjDef) {
+    this.map.getLayers().getArray().forEach((layerGroup: olLayerGroup) => {
+      layerGroup.getLayers().getArray().forEach(layer => {
+        if (layer instanceof olLayer) {
+          const newEpsg = projection?.code;
+          this.reprojectVectorLayers(layer, oldEpsg, newEpsg);
+          this.setLayerExtentAfterProjection(layer, newEpsg);
+        } else {
+          console.log(layer, 'no olLayer');
+        }
+      });
+    });
   }
 
   /**

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -105,6 +105,8 @@ const OL_GROUP_KEY = 'groupID';
 const OL_GROUP_NAME = 'groupName';
 const TITLE_KEY = 'title';
 const POPUP_KEY = 'popup';
+// Perhaps a function could be created that sets the stops for the transformation based on the EPSG.
+const transformExtentStops = 8;
 
 
 type tmsReturnType<T> = T extends RasterLayer ? olTileLayer<olTileSource> :
@@ -867,7 +869,7 @@ export class MapOlService {
     }
 
     if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
-      layeroptions.extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
+      layeroptions.extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
       layeroptions.bbox = l.bbox;
     } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
       layeroptions.extent = [...l.nativeBbox.bbox];
@@ -1382,7 +1384,7 @@ export class MapOlService {
 
           /** fix set bbox for layers in olLayerGroup not only for the group */
           if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
-            const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
+            const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
             gl.setExtent(extent);
           } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
             gl.setExtent([...l.nativeBbox.bbox]);
@@ -1428,7 +1430,7 @@ export class MapOlService {
       }
 
       if (l.bbox && l?.nativeBbox?.epsg !== currentProjection) {
-        const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection);
+        const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
         layer.setExtent(extent);
       } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
         layer.setExtent([...l.nativeBbox.bbox]);
@@ -2395,7 +2397,7 @@ export class MapOlService {
    */
   public setExtent(extent: TGeoExtent, geographic?: boolean, fitOptions?: olFitOptions): TGeoExtent {
     const projection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
-    const transfomExtent = transformExtent(extent.slice(0, 4) as [number, number, number, number], projection, this.getProjection().getCode());
+    const transfomExtent = transformExtent(extent.slice(0, 4) as [number, number, number, number], projection, this.getProjection().getCode(), transformExtentStops);
     const newFitOptions: olFitOptions = {
       size: this.map.getSize(),
       // padding: [100, 200, 100, 100] // Padding (in pixels) to be cleared inside the view. Values in the array are top, right, bottom and left padding. Default is [0, 0, 0, 0].
@@ -2442,7 +2444,7 @@ export class MapOlService {
     });
     if (geographic) {
       const projection = getProjection(WGS84);
-      const transfomExtent = transformExtent(extent, this.getProjection().getCode(), projection);
+      const transfomExtent = transformExtent(extent, this.getProjection().getCode(), projection, transformExtentStops);
       return (transfomExtent as TGeoExtent);
     } else {
       return extent;
@@ -2457,7 +2459,7 @@ export class MapOlService {
   public getCurrentExtent(geographic?: boolean): TGeoExtent {
     const projection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
     const extent = this.map.getView().calculateExtent();
-    const transfomExtent = transformExtent(extent, this.getProjection().getCode(), projection);
+    const transfomExtent = transformExtent(extent, this.getProjection().getCode(), projection, transformExtentStops);
     return (transfomExtent as TGeoExtent);
   }
 
@@ -2653,16 +2655,32 @@ export class MapOlService {
    * set or calculate the new layer extent after reprojectFeatures
    */
   private setLayerExtentAfterProjection(layer: olLayer, newEpsg: string) {
-    const bbox: TGeoExtent = layer.get('bbox');
-    const nativeBbox: Layer['nativeBbox'] = layer.get('nativeBbox');
-    const newLayerExt = layer.getExtent();
-    if (bbox && nativeBbox?.epsg !== newEpsg) {
-      const newLExt = transformExtent(bbox.slice(0, 4) as [number, number, number, number], WGS84, newEpsg);
-      layer.setExtent(newLExt);
-    } else if (nativeBbox?.epsg === newEpsg) {
+    const bbox = layer.get('bbox') as number[] | undefined;
+    const nativeBbox = layer.get('nativeBbox') as | { epsg: string; bbox: TGeoExtent } | undefined;
+    const currentExtent = layer.getExtent() as olExtent | undefined;
+
+    // nativeBbox exists and matches newEpsg -> use nativeBbox
+    if (nativeBbox && nativeBbox.epsg === newEpsg) {
       layer.setExtent(nativeBbox.bbox);
-    } else if (newLayerExt?.length) {
-      // if the layer has an extent specified but no bbox or nativeBbox has been defined
+      return;
+    }
+
+    // bbox exists and nativeBbox is missing OR has different epsg -> use bbox
+    if (bbox && (!nativeBbox || nativeBbox.epsg !== newEpsg)) {
+      if (bbox.length >= 4) {
+        const ext = transformExtent(bbox.slice(0, 4), WGS84, newEpsg, transformExtentStops);
+        if (ext.includes(NaN)) {
+          layer.setExtent(undefined);
+        } else {
+          layer.setExtent(ext);
+        }
+
+      }
+      return;
+    }
+
+    // no bbox and no nativeBbox -> clear any old defined extent
+    if (!bbox && !nativeBbox && currentExtent) {
       layer.setExtent(undefined);
     }
   }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -98,8 +98,6 @@ const ID_KEY = 'id';
 const OL_GROUP_KEY = 'groupID';
 const OL_GROUP_NAME = 'groupName';
 const TITLE_KEY = 'title';
-const WebMercator = 'EPSG:3857';
-const WGS84 = 'EPSG:4326';
 const POPUP_KEY = 'popup';
 
 

--- a/projects/map-three/package.json
+++ b/projects/map-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-three",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,10 +19,10 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
-    "@dlr-eoc/map-ol": "16.0.0-next.6",
-    "@dlr-eoc/utils-maps": "16.0.0-next.6",
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/map-ol": "16.0.0-next.7",
+    "@dlr-eoc/utils-maps": "16.0.0-next.7",
     "proj4": "^2.17.0",
     "tslib": "^2.6.3",
     "three": "^0.176.0"

--- a/projects/map-three/package.json
+++ b/projects/map-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-three",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,10 +19,10 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
-    "@dlr-eoc/map-ol": "16.0.0-next.7",
-    "@dlr-eoc/utils-maps": "16.0.0-next.7",
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
+    "@dlr-eoc/map-ol": "16.0.0-next.8",
+    "@dlr-eoc/utils-maps": "16.0.0-next.8",
     "proj4": "^2.17.0",
     "tslib": "^2.6.3",
     "three": "^0.176.0"

--- a/projects/map-three/package.json
+++ b/projects/map-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-three",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,10 +19,10 @@
     "@angular/core": "^19.2.19"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
-    "@dlr-eoc/map-ol": "16.0.0-next.5",
-    "@dlr-eoc/utils-maps": "16.0.0-next.5",
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/map-ol": "16.0.0-next.6",
+    "@dlr-eoc/utils-maps": "16.0.0-next.6",
     "proj4": "^2.17.0",
     "tslib": "^2.6.3",
     "three": "^0.176.0"

--- a/projects/ngx-ukis-ui-clarity/map-tools.md
+++ b/projects/ngx-ukis-ui-clarity/map-tools.md
@@ -5,9 +5,9 @@
 This repository contains 3 ui components:
 
 1. mouse-position: shows projected coordinates of mouse pointer <br />
- ```<ukis-mouse-position></ukis-mouse-position>```
+ ```<ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc"></ukis-mouse-position>```
 2. navigator: allows to insert coordinates in order to navigate the map to desired position <br />
- ```<ukis-projection-switch [mapSvc]="mapSvc" [projectionList]="projections"></ukis-projection-switch>```
+ ```<ukis-projection-switch [mapSvc]="mapSvc" [mapState]="mapStateSvc" [projectionList]="projections"></ukis-projection-switch>```
 3. projection-switch: ui element for interactive projection switch <br />
  ```<ukis-map-navigator [mapState]="mapStateSvc"></ukis-map-navigator>```
 
@@ -87,7 +87,7 @@ addBaselayers() {
     <cds-icon shape="compass" clrVerticalNavIcon></cds-icon>
     Coordinates
     <clr-vertical-nav-group-children class="padding title-ellipsis">
-      <ukis-mouse-position></ukis-mouse-position>
+      <ukis-mouse-position [mapSvc]="mapSvc" [mapState]="mapStateSvc"></ukis-mouse-position>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
 </clr-vertical-nav>

--- a/projects/ngx-ukis-ui-clarity/package.json
+++ b/projects/ngx-ukis-ui-clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "description": "This project includes schematics to add a base UKIS-Layout to an angular application. The Layout is based on Clarity so [add this first](https://clarity.design/get-started/developing/angular)!",
   "keywords": [
     "schematics",
@@ -45,10 +45,10 @@
     "jsonc-parser": "^3.3.1",
     "ol": "^v10.8.0",
     "proj4": "^2.17.0",
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
-    "@dlr-eoc/map-ol": "16.0.0-next.6"
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
+    "@dlr-eoc/map-ol": "16.0.0-next.7"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {

--- a/projects/ngx-ukis-ui-clarity/package.json
+++ b/projects/ngx-ukis-ui-clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "description": "This project includes schematics to add a base UKIS-Layout to an angular application. The Layout is based on Clarity so [add this first](https://clarity.design/get-started/developing/angular)!",
   "keywords": [
     "schematics",
@@ -45,10 +45,10 @@
     "jsonc-parser": "^3.3.1",
     "ol": "^v10.8.0",
     "proj4": "^2.17.0",
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
-    "@dlr-eoc/map-ol": "16.0.0-next.7"
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.8",
+    "@dlr-eoc/map-ol": "16.0.0-next.8"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {

--- a/projects/ngx-ukis-ui-clarity/package.json
+++ b/projects/ngx-ukis-ui-clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "description": "This project includes schematics to add a base UKIS-Layout to an angular application. The Layout is based on Clarity so [add this first](https://clarity.design/get-started/developing/angular)!",
   "keywords": [
     "schematics",
@@ -45,10 +45,10 @@
     "jsonc-parser": "^3.3.1",
     "ol": "^v10.8.0",
     "proj4": "^2.17.0",
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.5",
-    "@dlr-eoc/map-ol": "16.0.0-next.5"
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
+    "@dlr-eoc/map-ol": "16.0.0-next.6"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {

--- a/projects/ngx-ukis-ui-clarity/src/lib/layerentry-group/layerentry-group.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/layerentry-group/layerentry-group.component.ts
@@ -23,10 +23,10 @@ enum EactiveTabs {
 type TactiveTabs = keyof typeof EactiveTabs;
 
 @Component({
-    selector: 'ukis-layerentry-group',
-    templateUrl: './layerentry-group.component.html',
-    styleUrls: ['./layerentry-group.component.scss'],
-    imports: [ClrIconModule, NgClass, ClrCommonFormsModule, CdkDropList, CdkDrag, LayerentryComponent, CdkDragHandle, ItemsFilterPipe, ReversePipe, DynamicComponent]
+  selector: 'ukis-layerentry-group',
+  templateUrl: './layerentry-group.component.html',
+  styleUrls: ['./layerentry-group.component.scss'],
+  imports: [ClrIconModule, NgClass, ClrCommonFormsModule, CdkDropList, CdkDrag, LayerentryComponent, CdkDragHandle, ItemsFilterPipe, ReversePipe, DynamicComponent]
 })
 export class LayerentryGroupComponent implements OnInit {
   @HostBinding('class.group-visible') get visible() { return this.group.visible; }
@@ -77,7 +77,7 @@ export class LayerentryGroupComponent implements OnInit {
       if (Object.keys(EactiveTabs).includes(this.group.expanded.tab)) {
         this.switchTab(this.group.expanded.tab as TactiveTabs);
         /** let the user reset the default open tab */
-        if(this.group.expanded.expanded === false){
+        if (this.group.expanded.expanded === false) {
           this.activeTabs[this.group.expanded.tab] = false;
         }
       } else {
@@ -187,8 +187,13 @@ export class LayerentryGroupComponent implements OnInit {
 
 
   zoomTo(group: LayerGroup) {
-    if (this.mapState && group.bbox && group.bbox.length >= 4) {
-      this.mapState.setExtent(group.bbox);
+    if (this.mapState) {
+      const state = this.mapState.getMapState().value;
+      if (group.bbox && group?.nativeBbox?.epsg !== state?.proj?.epsg) {
+        this.mapState.setExtent(group.bbox);
+      } else if (group.nativeBbox && group.nativeBbox.epsg === state?.proj?.epsg) {
+        this.mapState.setNativeExtent(group.nativeBbox.bbox)
+      }
     }
   }
 

--- a/projects/ngx-ukis-ui-clarity/src/lib/layerentry/layerentry.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/layerentry/layerentry.component.ts
@@ -257,8 +257,13 @@ export class LayerentryComponent implements OnInit {
   }
 
   zoomTo(layer: Layer) {
-    if (this.mapState && layer.bbox && layer.bbox.length >= 4) {
-      this.mapState.setExtent(layer.bbox as [number, number, number, number]);
+    if (this.mapState) {
+      const state = this.mapState.getMapState().value;
+      if (layer.bbox && layer?.nativeBbox?.epsg !== state?.proj?.epsg) {
+        this.mapState.setExtent(layer.bbox);
+      } else if (layer.nativeBbox && layer.nativeBbox.epsg === state?.proj?.epsg) {
+        this.mapState.setNativeExtent(layer.nativeBbox.bbox);
+      }
     }
   }
 

--- a/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.spec.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.spec.ts
@@ -2,24 +2,30 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { MousePositionComponent } from './mouse-position.component';
 import { FormsModule } from '@angular/forms';
-import { MapOlService } from '@dlr-eoc/map-ol';
 import { ClarityModule } from '@clr/angular';
+import { MapStateService } from '@dlr-eoc/services-map-state';
+import { MapOlService } from '@dlr-eoc/map-ol';
 
 describe('MousePositionComponent', () => {
   let component: MousePositionComponent;
   let fixture: ComponentFixture<MousePositionComponent>;
+  let mapStateSvc: MapStateService;
+  let mapOlSvc: MapOlService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-    imports: [FormsModule, ClarityModule, MousePositionComponent],
-    providers: [MapOlService]
-})
+      imports: [FormsModule, ClarityModule, MousePositionComponent]
+    })
       .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MousePositionComponent);
     component = fixture.componentInstance;
+    mapStateSvc = TestBed.inject(MapStateService);
+    mapOlSvc = TestBed.inject(MapOlService);
+    component.mapState = mapStateSvc;
+    component.mapSvc = mapOlSvc;
     fixture.detectChanges();
   });
 

--- a/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { MapOlService } from '@dlr-eoc/map-ol';
 import { transform as olTransform, get as olGetProjection, Projection as olProjection } from 'ol/proj';
-import { Subscription } from 'rxjs';
+import { distinctUntilChanged, Subscription } from 'rxjs';
 import { ClrSelectModule, ClrCommonFormsModule, ClrNumberInputModule } from '@clr/angular';
 
 import { FormsModule } from '@angular/forms';
+import { MapStateService } from '@dlr-eoc/services-map-state';
 
 interface ISelectProjection {
   title: string;
@@ -12,13 +13,14 @@ interface ISelectProjection {
 }
 
 @Component({
-    selector: 'ukis-mouse-position',
-    templateUrl: './mouse-position.component.html',
-    styleUrls: ['./mouse-position.component.scss'],
-    imports: [ClrSelectModule, ClrCommonFormsModule, FormsModule, ClrNumberInputModule]
+  selector: 'ukis-mouse-position',
+  templateUrl: './mouse-position.component.html',
+  styleUrls: ['./mouse-position.component.scss'],
+  imports: [ClrSelectModule, ClrCommonFormsModule, FormsModule, ClrNumberInputModule]
 })
 export class MousePositionComponent implements OnInit, OnDestroy {
-
+  @Input('mapSvc') mapSvc: MapOlService;
+  @Input('mapState') mapState: MapStateService;
   public mapCoordinates: [number, number] | number[] = [0, 0];
   public zoom = 0;
   public projections: ISelectProjection[];
@@ -28,23 +30,27 @@ export class MousePositionComponent implements OnInit, OnDestroy {
   x = 'Lon';
   y = 'Lat';
   mapSub: Subscription;
-  constructor(public mapSvc: MapOlService) {
-    this.mapSub = this.mapSvc.projectionChange.subscribe(projLike => {
-      this.mapProjection = projLike;
-      this.setProjection(projLike);
-    });
+  constructor() {
   }
 
   ngOnInit() {
-    this.mapSvc.map.on('pointermove', this.mapMoveSubscription);
-    this.mapSvc.map.on('moveend', this.mapOnMoveend);
+    this.mapSub = this.mapState.getProjection().pipe(distinctUntilChanged()).subscribe(epsg => {
+      this.mapProjection = olGetProjection(epsg);
+      this.setProjection(epsg);
+    });
+
+    this.mapProjection = this.mapSvc.getProjection();
+    this.setProjection(this.mapProjection.getCode());
+
+    // TODO: remove listeneres on destry
+    const onMove = this.mapSvc.map.on('pointermove', this.mapMoveSubscription);
+    const onMoveEnd = this.mapSvc.map.on('moveend', this.mapOnMoveend);
   }
 
   /**
    * projLike: 'olProjection'
    */
-  setProjection(projLike: any) {
-    const epsg = projLike.getCode();
+  setProjection(epsg: string) {
     if (epsg === 'EPSG:4326') {
       this.projections = [
         { title: epsg, value: epsg }

--- a/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
@@ -34,9 +34,9 @@ export class MousePositionComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.mapSub = this.mapState.getProjection().pipe(distinctUntilChanged()).subscribe(epsg => {
-      this.mapProjection = olGetProjection(epsg);
-      this.setProjection(epsg);
+    this.mapSub = this.mapState.getProjection().pipe(distinctUntilChanged()).subscribe(item => {
+      this.mapProjection = olGetProjection(item.epsg);
+      this.setProjection(item.epsg);
     });
 
     this.mapProjection = this.mapSvc.getProjection();

--- a/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
@@ -35,8 +35,10 @@ export class MousePositionComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.mapSub = this.mapState.getProjection().pipe(distinctUntilChanged()).subscribe(item => {
-      this.mapProjection = olGetProjection(item.epsg);
-      this.setProjection(item.epsg);
+      if (item.epsg) {
+        this.mapProjection = olGetProjection(item.epsg);
+        this.setProjection(item.epsg);
+      }
     });
 
     this.mapProjection = this.mapSvc.getProjection();

--- a/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.spec.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.spec.ts
@@ -4,18 +4,20 @@ import { ProjectionSwitchComponent } from './projection-switch.component';
 import { ClarityModule } from '@clr/angular';
 import { FormsModule } from '@angular/forms';
 import { MapOlService } from '@dlr-eoc/map-ol';
+import { MapStateService } from '@dlr-eoc/services-map-state';
 
 describe('ProjectionSwitchComponent', () => {
   let component: ProjectionSwitchComponent;
   let fixture: ComponentFixture<ProjectionSwitchComponent>;
   let mapSvc: MapOlService;
+  let mapStateSvc: MapStateService;
   const projList: any[] = [];
 
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-    imports: [ClarityModule, FormsModule, ProjectionSwitchComponent]
-})
+      imports: [ClarityModule, FormsModule, ProjectionSwitchComponent]
+    })
       .compileComponents();
   }));
 
@@ -23,6 +25,8 @@ describe('ProjectionSwitchComponent', () => {
     fixture = TestBed.createComponent(ProjectionSwitchComponent);
     component = fixture.componentInstance;
     mapSvc = TestBed.inject(MapOlService);
+    mapStateSvc = TestBed.inject(MapStateService);
+    component.mapState = mapStateSvc;
     component.mapSvc = mapSvc;
     component.projList = projList;
     fixture.detectChanges();

--- a/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
@@ -19,6 +19,7 @@ ClarityIcons.addIcons(...[eyeIcon, eyeHideIcon]);
 })
 export class ProjectionSwitchComponent implements OnInit {
   @Input('mapSvc') mapSvc: MapOlService;
+  @Input('mapState') mapState: MapStateService;
   @Input('projectionList') projList: IProjDef[];
   @Input('fitViewToNewExtent') fitViewToNewExtent? = false;
   subscription: Subscription;

--- a/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MapOlService } from '@dlr-eoc/map-ol';
 
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { IProjDef, MapStateService } from '@dlr-eoc/services-map-state';
 
 import { ClarityIcons, eyeIcon, eyeHideIcon } from '@cds/core/icon';
 
@@ -10,12 +10,12 @@ import { ClrIconModule } from '@clr/angular';
 ClarityIcons.addIcons(...[eyeIcon, eyeHideIcon]);
 
 @Component({
-    selector: 'ukis-projection-switch',
-    templateUrl: './projection-switch.component.html',
-    styles: [],
-    imports: [
-        ClrIconModule
-    ]
+  selector: 'ukis-projection-switch',
+  templateUrl: './projection-switch.component.html',
+  styles: [],
+  imports: [
+    ClrIconModule
+  ]
 })
 export class ProjectionSwitchComponent implements OnInit {
   @Input('mapSvc') mapSvc: MapOlService;
@@ -32,21 +32,13 @@ export class ProjectionSwitchComponent implements OnInit {
     }
   }
 
+  /** if you setProjection is used only with epsg code sting - register Projection have to be called first! */
   setNewProjection(projection: IProjDef) {
-    this.mapSvc.registerProjection(projection);
-    const newProj = this.mapSvc.getOlProjection(projection);
-    this.mapSvc.setProjection(newProj, this.fitViewToNewExtent);
+    const currentEpsg = this.mapSvc.getProjection().getCode();
+    if (currentEpsg !== projection.code) {
+      this.mapState.setProjection(projection, 'user', { fitToProjectionExtent: this.fitViewToNewExtent });
+    }
     this.selectedProj = projection;
   }
-}
-
-export interface IProjDef {
-  code: string; // e.g.: "EPSG:3857"
-  proj4js: string; // ' proj4 string, e.g.: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"
-  title: string; // projection title shown on switch, e.g.: "Spherical Mercator",
-  extent: [number, number, number, number]; // projection extent in projected coordinates, e.g.: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
-  worldExtent: [number, number, number, number]; // projection extent in geographical coordinates, e.g.:[-180.0, -85.06, 180.0, 85.06],
-  global: true | false; // whether is global or local projection
-  units: 'm';
 }
 

--- a/projects/ngx-ukis-utilities/package.json
+++ b/projects/ngx-ukis-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-utilities",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "description": "Angular utilities for @dlr-eoc ukis frontends",
   "keywords": [
     "angular",

--- a/projects/ngx-ukis-utilities/package.json
+++ b/projects/ngx-ukis-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-utilities",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "description": "Angular utilities for @dlr-eoc ukis frontends",
   "keywords": [
     "angular",

--- a/projects/ngx-ukis-utilities/package.json
+++ b/projects/ngx-ukis-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-utilities",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "description": "Angular utilities for @dlr-eoc ukis frontends",
   "keywords": [
     "angular",

--- a/projects/services-layers/package.json
+++ b/projects/services-layers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-layers",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7"
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.8",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8"
   },
   "dependencies": {
     "tslib": "^2.6.3"

--- a/projects/services-layers/package.json
+++ b/projects/services-layers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-layers",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6"
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7"
   },
   "dependencies": {
     "tslib": "^2.6.3"

--- a/projects/services-layers/package.json
+++ b/projects/services-layers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-layers",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.5",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5"
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6"
   },
   "dependencies": {
     "tslib": "^2.6.3"

--- a/projects/services-layers/src/lib/types/LayerGroup.ts
+++ b/projects/services-layers/src/lib/types/LayerGroup.ts
@@ -16,6 +16,12 @@ export interface ILayerGroupOptions {
   removable?: boolean;
   layerRemovable?: boolean;
   bbox?: TGeoExtent;
+  nativeBbox?: {
+    /** the EPSG code for the bbox  */
+    epsg:string,
+    /** native coordinates for projected layers - this can be helpful when zooming to the extent of a projected layer */
+    bbox: TGeoExtent
+  };
   /** description for the group as string/html or a angular component */
   description?: string | IDynamicComponent;
   /** legend for the group as image or a angular component */
@@ -46,7 +52,11 @@ export class LayerGroup implements ILayerGroupOptions {
   filtertype?: TFiltertypes = 'Layers';
   removable = true;
   layerRemovable = true;
-  bbox?: [number, number, number, number];
+  bbox?: TGeoExtent;
+  nativeBbox?: {
+    epsg:string,
+    bbox: TGeoExtent
+  };
   description?: string | IDynamicComponent;
   legendImg?: string | IDynamicComponent;
   actions?: [{ title: string, icon: string, action: (LayerGroup) => void }];

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -133,7 +133,6 @@ export function isLayertype(type: string): type is TLayertype {
 }
 
 /**
- * geographic coordinates
  * like ol.extent: minX, minY, maxX, maxY
  */
 export type TGeoExtent = [number, number, number, number] | [number, number, number, number, number, number];

--- a/projects/services-layers/src/lib/types/Layers.ts
+++ b/projects/services-layers/src/lib/types/Layers.ts
@@ -179,6 +179,12 @@ export interface ILayerOptions<T = any > {
   legendImg?: string | IDynamicComponent;
   /** geographic coordinates */
   bbox?: TGeoExtent;
+  nativeBbox?: {
+    /** the EPSG code for the bbox  */
+    epsg:string,
+    /** native coordinates for projected layers - this can be helpful when zooming to the extent of a projected layer */
+    bbox: TGeoExtent
+  };
   dimensions?: ILayerDimensions;
   /** true: show popup on click | array: show popup on click and limit properties | or use a popup object to configure the popup
    * if a popup should be shown on multiple events use an array of popup object (only unique events)
@@ -317,6 +323,10 @@ export class Layer<T = any> implements ILayerOptions<T>{
   legendImg?: string | IDynamicComponent;
 
   bbox?: TGeoExtent;
+  nativeBbox?: {
+    epsg:string,
+    bbox: TGeoExtent
+  };
   dimensions?: ILayerDimensions;
 
   popup?: ILayerOptions['popup'];

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-map-state",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,7 +20,7 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-map-state",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,7 +20,7 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-map-state",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,7 +20,7 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/services-map-state/src/lib/map-state.service.spec.ts
+++ b/projects/services-map-state/src/lib/map-state.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { MapStateService } from './map-state.service';
 import { MapState, TGeoExtent, IMapState } from './types/map-state';
+import { WebMercator, WGS84 } from './types/projections';
 
 describe('MapStateService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
@@ -65,6 +66,20 @@ describe('MapStateService', () => {
   }));
 
 
+  it('should set/get the current nativeExtent', waitForAsync(() => {
+    const service: MapStateService = TestBed.inject(MapStateService);
+    const extent: TGeoExtent = [-10, -10, 10, 10];
+
+    service.setNativeExtent(extent);
+    service.getNativeExtent().subscribe((nativeExtent) => {
+      expect(nativeExtent[0]).toEqual(-10);
+      expect(nativeExtent[1]).toEqual(-10);
+      expect(nativeExtent[2]).toEqual(10);
+      expect(nativeExtent[3]).toEqual(10);
+    });
+  }));
+
+
   it('should set/get the current time', waitForAsync(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
 
@@ -95,6 +110,23 @@ describe('MapStateService', () => {
     expect(state.sameCenter(state2.center)).toBe(false);
     expect(state.sameZoom(state2.zoom)).toBe(false);
     expect(state.sameNotifier(state2.options.notifier)).toBe(false);
+  }));
+
+  it('should have a initial MapState epsg for WebMercator', waitForAsync(() => {
+    const service: MapStateService = TestBed.inject(MapStateService);
+    service.getMapState().subscribe((state) => {
+      expect(state.epsg).toEqual(WebMercator);
+    });
+  }));
+
+  it('should set/get the current Projection (epsg)', waitForAsync(() => {
+    const service: MapStateService = TestBed.inject(MapStateService);
+
+    const epsg = WGS84;
+    service.setProjection(epsg);
+    service.getProjection().subscribe((proj) => {
+      expect(proj).toEqual(epsg);
+    });
   }));
 
 

--- a/projects/services-map-state/src/lib/map-state.service.spec.ts
+++ b/projects/services-map-state/src/lib/map-state.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { MapStateService } from './map-state.service';
-import { MapState, TGeoExtent, IMapState } from './types/map-state';
-import { EPSG_4326_Def, WebMercator, WGS84 } from './types/projections';
+import { MapState, IMapState } from './types/map-state';
+import { EPSG_4326_Def, WebMercator } from './types/projections';
+import { TGeoExtent } from '@dlr-eoc/services-layers';
 
 describe('MapStateService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));

--- a/projects/services-map-state/src/lib/map-state.service.spec.ts
+++ b/projects/services-map-state/src/lib/map-state.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { MapStateService } from './map-state.service';
 import { MapState, TGeoExtent, IMapState } from './types/map-state';
-import { WebMercator, WGS84 } from './types/projections';
+import { EPSG_4326_Def, WebMercator, WGS84 } from './types/projections';
 
 describe('MapStateService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
@@ -115,17 +115,16 @@ describe('MapStateService', () => {
   it('should have a initial MapState epsg for WebMercator', waitForAsync(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
     service.getMapState().subscribe((state) => {
-      expect(state.epsg).toEqual(WebMercator);
+      expect(state.proj.epsg).toEqual(WebMercator);
     });
   }));
 
   it('should set/get the current Projection (epsg)', waitForAsync(() => {
     const service: MapStateService = TestBed.inject(MapStateService);
 
-    const epsg = WGS84;
-    service.setProjection(epsg);
+    service.setProjection(EPSG_4326_Def);
     service.getProjection().subscribe((proj) => {
-      expect(proj).toEqual(epsg);
+      expect(proj.epsg).toEqual(EPSG_4326_Def.code);
     });
   }));
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { MapState, IMapStateOptions, IMapState, IProjOptions } from './types/map-state';
+import { MapState, IMapStateOptions, IMapState, IProjOptions, IMapStateProjection } from './types/map-state';
 import { TGeoExtent } from '@dlr-eoc/services-layers';
 import { map } from 'rxjs/operators';
 import { IProjDef } from './types/projections';
@@ -10,8 +10,11 @@ const initialState = new MapState(0, { lat: 0, lon: 0 });
   providedIn: 'root'
 })
 export class MapStateService {
+  // TODO: more refactoring to signals
   private mapState = new BehaviorSubject(initialState)
   private lastAction = new BehaviorSubject<'setExtent' | 'setNativeExtent' | 'setState' | 'setRotation' | 'setAngle' | 'setTime' | 'setProjection'>(null);
+
+  private _registeredProjections = signal<IProjDef[]>([]);
   constructor() {
   }
 
@@ -112,12 +115,19 @@ export class MapStateService {
    * This then needs to be processed by the associated map component.
    * @param epsg - https://epsg.io/
    */
-  public setProjection(epsg: IProjDef['code'], notifier: IMapState['options']['notifier'] = 'user', options?: IProjOptions) {
-    const state = this.getMapState().getValue();
-    const currentEPSG = state.epsg;
-    if (epsg !== currentEPSG) {
+  public setProjection(projection: IProjDef | IProjDef['code'], notifier: IMapState['options']['notifier'] = 'user', options?: IProjOptions) {
+    let projIsReg = this._registeredProjections().find(p => (typeof projection === 'string') ? p.code === projection : p.code === projection.code);
+
+    // IProjDef is used and it is not registered, register it and use it.
+    if (typeof projection !== 'string' && !projIsReg) {
+      this.registerProjection(projection);
+      projIsReg = this._registeredProjections().find(p => p.code === projection.code)
+    }
+
+    if (projIsReg) {
+      const state = this.getMapState().getValue();
       this.lastAction.next('setProjection');
-      state.epsg = epsg;
+      state.epsg = projIsReg.code;
       state.options.notifier = notifier;
       if (options?.fitToBbox) {
         state.extent = options.fitToBbox;
@@ -127,13 +137,39 @@ export class MapStateService {
       }
       const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg, options);
       this.mapState.next(newState);
+    } else {
+      console.info(`projection ${projection} is not registered!`);
     }
   }
 
   public getProjection() {
-    return this.mapState.pipe(map((state) => state.epsg));
+    return this.mapState.pipe(map((state) => {
+      const hasDef = this._registeredProjections().find(p => p.code === state.epsg);
+      const item: IMapStateProjection = { epsg: state.epsg, projOptions: state.projOptions };
+      if (hasDef) {
+        item.IProjDef = hasDef;
+      }
+      return item;
+    }));
   }
 
+  public registerProjection(proj: IProjDef) {
+    const currentProjections = this._registeredProjections();
+    const itemIndex = currentProjections.findIndex(p => p.code === proj.code);
+    let next: IProjDef[];
+    if (itemIndex === -1) {
+      next = [...currentProjections, proj];
+    } else {
+      next = currentProjections.map((p, i) =>
+        i === itemIndex ? proj : p
+      );
+    }
+    this._registeredProjections.set(next);
+  }
+
+  public get registeredProjections() {
+    return this._registeredProjections.asReadonly();
+  }
 
   public getLastAction() {
     return this.lastAction;

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { MapState, IMapStateOptions, IMapState, IProjOptions, IMapStateProjection } from './types/map-state';
+import { MapState, IMapStateOptions, IMapState, IProjFitOptions, IMapStateProjection } from './types/map-state';
 import { TGeoExtent } from '@dlr-eoc/services-layers';
 import { map } from 'rxjs/operators';
 import { IProjDef } from './types/projections';
@@ -28,11 +28,11 @@ export class MapStateService {
     }
     this.lastAction.next('setState');
     if (state instanceof MapState) {
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
       this.mapState.next(newState);
     } else {
       const stateOptions: IMapStateOptions = { ...{ notifier: 'user' }, ...state.options };
-      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
+      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
       this.mapState.next(newState);
     }
   }
@@ -48,7 +48,7 @@ export class MapStateService {
     this.lastAction.next('setExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
     this.mapState.next(newState);
   }
 
@@ -63,7 +63,7 @@ export class MapStateService {
     this.lastAction.next('setNativeExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
     this.mapState.next(newState);
   }
 
@@ -95,7 +95,7 @@ export class MapStateService {
     this.lastAction.next('setAngle');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.proj?.epsg);
     this.mapState.next(newState);
   }
 
@@ -106,16 +106,17 @@ export class MapStateService {
     this.lastAction.next('setRotation');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.proj?.epsg);
     this.mapState.next(newState);
   }
 
   /**
-   * set a projection epsg code
-   * This then needs to be processed by the associated map component.
-   * @param epsg - https://epsg.io/
+   * Set a projection in the MapState so that map components like map-ol can listen to it.
+   * 
+   * If you use setProjection only with epsg code sting - registerProjection have to be called first!
+   * See https://epsg.io/
    */
-  public setProjection(projection: IProjDef | IProjDef['code'], notifier: IMapState['options']['notifier'] = 'user', options?: IProjOptions) {
+  public setProjection(projection: IProjDef | IProjDef['code'], notifier: IMapState['options']['notifier'] = 'user', fitOptions?: IProjFitOptions) {
     let projIsReg = this._registeredProjections().find(p => (typeof projection === 'string') ? p.code === projection : p.code === projection.code);
 
     // IProjDef is used and it is not registered, register it and use it.
@@ -127,15 +128,21 @@ export class MapStateService {
     if (projIsReg) {
       const state = this.getMapState().getValue();
       this.lastAction.next('setProjection');
-      state.epsg = projIsReg.code;
+      if (!state.proj) {
+        state.proj = {};
+      }
+      state.proj.epsg = projIsReg.code;
+      if (fitOptions) {
+        state.proj.fitOptions = fitOptions;
+      }
       state.options.notifier = notifier;
-      if (options?.fitToBbox) {
-        state.extent = options.fitToBbox;
+      if (fitOptions?.fitToBbox) {
+        state.extent = fitOptions.fitToBbox;
       }
-      if (options?.fitToNativeBbox) {
-        state.nativeExtent = options.fitToNativeBbox;
+      if (fitOptions?.fitToNativeBbox) {
+        state.nativeExtent = fitOptions.fitToNativeBbox;
       }
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg, options);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg, fitOptions);
       this.mapState.next(newState);
     } else {
       console.info(`projection ${projection} is not registered!`);
@@ -144,8 +151,8 @@ export class MapStateService {
 
   public getProjection() {
     return this.mapState.pipe(map((state) => {
-      const hasDef = this._registeredProjections().find(p => p.code === state.epsg);
-      const item: IMapStateProjection = { epsg: state.epsg, projOptions: state.projOptions };
+      const hasDef = this._registeredProjections().find(p => p.code === state.proj.epsg);
+      const item: IMapStateProjection = { epsg: state.proj.epsg, fitOptions: state.proj.fitOptions };
       if (hasDef) {
         item.IProjDef = hasDef;
       }

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -28,11 +28,11 @@ export class MapStateService {
     }
     this.lastAction.next('setState');
     if (state instanceof MapState) {
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg, state.proj.fitOptions);
       this.mapState.next(newState);
     } else {
       const stateOptions: IMapStateOptions = { ...{ notifier: 'user' }, ...state.options };
-      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
+      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg, state.proj?.fitOptions);
       this.mapState.next(newState);
     }
   }
@@ -49,7 +49,7 @@ export class MapStateService {
     this.lastAction.next('setExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg, state.proj.fitOptions);
     this.mapState.next(newState);
   }
 
@@ -64,7 +64,7 @@ export class MapStateService {
     this.lastAction.next('setNativeExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg, state.proj.fitOptions);
     this.mapState.next(newState);
   }
 
@@ -96,7 +96,7 @@ export class MapStateService {
     this.lastAction.next('setAngle');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.proj.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.proj.epsg, state.proj.fitOptions);
     this.mapState.next(newState);
   }
 
@@ -107,7 +107,7 @@ export class MapStateService {
     this.lastAction.next('setRotation');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.proj.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.proj.epsg, state.proj.fitOptions);
     this.mapState.next(newState);
   }
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { MapState, IMapStateOptions, IMapState } from './types/map-state';
+import { MapState, IMapStateOptions, IMapState, IProjOptions } from './types/map-state';
 import { TGeoExtent } from '@dlr-eoc/services-layers';
 import { map } from 'rxjs/operators';
 import { IProjDef } from './types/projections';
@@ -11,7 +11,7 @@ const initialState = new MapState(0, { lat: 0, lon: 0 });
 })
 export class MapStateService {
   private mapState = new BehaviorSubject(initialState)
-  private lastAction = new BehaviorSubject<'setExtent' | 'setState' | 'setRotation' | 'setAngle' | 'setTime'>(null);
+  private lastAction = new BehaviorSubject<'setExtent' | 'setNativeExtent' | 'setState' | 'setRotation' | 'setAngle' | 'setTime' | 'setProjection'>(null);
   constructor() {
   }
 
@@ -25,11 +25,11 @@ export class MapStateService {
     }
     this.lastAction.next('setState');
     if (state instanceof MapState) {
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, state.viewAngle, state.rotation);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
       this.mapState.next(newState);
     } else {
       const stateOptions: IMapStateOptions = { ...{ notifier: 'user' }, ...state.options };
-      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.time, state.viewAngle, state.rotation);
+      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
       this.mapState.next(newState);
     }
   }
@@ -45,7 +45,22 @@ export class MapStateService {
     this.lastAction.next('setExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, extent, state.time, state.viewAngle, state.rotation);
+    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
+    this.mapState.next(newState);
+  }
+
+  public getNativeExtent() {
+    return this.mapState.pipe(map((state) => state.nativeExtent));
+  }
+
+  public setNativeExtent(nativeExtent: TGeoExtent, notifier: IMapState['options']['notifier'] = 'user') {
+    if (!Array.isArray(nativeExtent)) {
+      return;
+    }
+    this.lastAction.next('setNativeExtent');
+    const state = this.getMapState().getValue();
+    state.options.notifier = notifier;
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg);
     this.mapState.next(newState);
   }
 
@@ -77,7 +92,7 @@ export class MapStateService {
     this.lastAction.next('setAngle');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, angle, state.rotation);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.epsg);
     this.mapState.next(newState);
   }
 
@@ -88,8 +103,35 @@ export class MapStateService {
     this.lastAction.next('setRotation');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.time, state.viewAngle, rotation);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.epsg);
     this.mapState.next(newState);
+  }
+
+  /**
+   * set a projection epsg code
+   * This then needs to be processed by the associated map component.
+   * @param epsg - https://epsg.io/
+   */
+  public setProjection(epsg: IProjDef['code'], notifier: IMapState['options']['notifier'] = 'user', options?: IProjOptions) {
+    const state = this.getMapState().getValue();
+    const currentEPSG = state.epsg;
+    if (epsg !== currentEPSG) {
+      this.lastAction.next('setProjection');
+      state.epsg = epsg;
+      state.options.notifier = notifier;
+      if (options?.fitToBbox) {
+        state.extent = options.fitToBbox;
+      }
+      if (options?.fitToNativeBbox) {
+        state.nativeExtent = options.fitToNativeBbox;
+      }
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.epsg, options);
+      this.mapState.next(newState);
+    }
+  }
+
+  public getProjection() {
+    return this.mapState.pipe(map((state) => state.epsg));
   }
 
 

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 import { MapState, IMapStateOptions, IMapState } from './types/map-state';
 import { TGeoExtent } from '@dlr-eoc/services-layers';
 import { map } from 'rxjs/operators';
+import { IProjDef } from './types/projections';
 
 const initialState = new MapState(0, { lat: 0, lon: 0 });
 @Injectable({

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -28,11 +28,11 @@ export class MapStateService {
     }
     this.lastAction.next('setState');
     if (state instanceof MapState) {
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
       this.mapState.next(newState);
     } else {
       const stateOptions: IMapStateOptions = { ...{ notifier: 'user' }, ...state.options };
-      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
+      const newState = new MapState(state.zoom, state.center, stateOptions, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
       this.mapState.next(newState);
     }
   }
@@ -49,7 +49,7 @@ export class MapStateService {
     this.lastAction.next('setExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
     this.mapState.next(newState);
   }
 
@@ -64,7 +64,7 @@ export class MapStateService {
     this.lastAction.next('setNativeExtent');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg);
     this.mapState.next(newState);
   }
 
@@ -96,7 +96,7 @@ export class MapStateService {
     this.lastAction.next('setAngle');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.proj?.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, angle, state.rotation, state.proj.epsg);
     this.mapState.next(newState);
   }
 
@@ -107,7 +107,7 @@ export class MapStateService {
     this.lastAction.next('setRotation');
     const state = this.getMapState().getValue();
     state.options.notifier = notifier;
-    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.proj?.epsg);
+    const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, rotation, state.proj.epsg);
     this.mapState.next(newState);
   }
 
@@ -129,9 +129,6 @@ export class MapStateService {
     if (projIsReg) {
       const state = this.getMapState().getValue();
       this.lastAction.next('setProjection');
-      if (!state.proj) {
-        state.proj = {};
-      }
       state.proj.epsg = projIsReg.code;
       if (fitOptions) {
         state.proj.fitOptions = fitOptions;
@@ -143,7 +140,7 @@ export class MapStateService {
       if (fitOptions?.fitToNativeBbox) {
         state.nativeExtent = fitOptions.fitToNativeBbox;
       }
-      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj?.epsg, fitOptions);
+      const newState = new MapState(state.zoom, state.center, state.options, state.extent, state.nativeExtent, state.time, state.viewAngle, state.rotation, state.proj.epsg, fitOptions);
       this.mapState.next(newState);
     } else {
       console.info(`projection ${projection} is not registered!`);

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -2,7 +2,7 @@ import { Injectable, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { MapState, IMapStateOptions, IMapState, IProjFitOptions, IMapStateProjection } from './types/map-state';
 import { TGeoExtent } from '@dlr-eoc/services-layers';
-import { map } from 'rxjs/operators';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import { IProjDef } from './types/projections';
 
 const initialState = new MapState(0, { lat: 0, lon: 0 });
@@ -37,6 +37,7 @@ export class MapStateService {
     }
   }
 
+  // TODO: maybe we should also check for changes her before emit? like getProjection
   public getExtent() {
     return this.mapState.pipe(map((state) => state.extent));
   }
@@ -150,7 +151,7 @@ export class MapStateService {
   }
 
   public getProjection() {
-    return this.mapState.pipe(map((state) => {
+    return this.mapState.pipe(distinctUntilChanged((prev, curr) => prev?.proj?.epsg === curr?.proj?.epsg),map((state) => {
       const hasDef = this._registeredProjections().find(p => p.code === state.proj.epsg);
       const item: IMapStateProjection = { epsg: state.proj.epsg, fitOptions: state.proj.fitOptions };
       if (hasDef) {

--- a/projects/services-map-state/src/lib/map-state.service.ts
+++ b/projects/services-map-state/src/lib/map-state.service.ts
@@ -148,14 +148,17 @@ export class MapStateService {
   }
 
   public getProjection() {
-    return this.mapState.pipe(distinctUntilChanged((prev, curr) => prev?.proj?.epsg === curr?.proj?.epsg),map((state) => {
-      const hasDef = this._registeredProjections().find(p => p.code === state.proj.epsg);
-      const item: IMapStateProjection = { epsg: state.proj.epsg, fitOptions: state.proj.fitOptions };
-      if (hasDef) {
-        item.IProjDef = hasDef;
-      }
-      return item;
-    }));
+    return this.mapState.pipe(map(state => ({
+      epsg: state.proj?.epsg,
+      fitOptions: state.proj?.fitOptions
+    })),
+      distinctUntilChanged((prev, curr) => prev.epsg === curr.epsg),
+      map(({ epsg, fitOptions }) => {
+        const item: any = { epsg, fitOptions };
+        const def = this._registeredProjections().find(p => p.code === epsg);
+        if (def) item.IProjDef = def;
+        return item;
+      }));
   }
 
   public registerProjection(proj: IProjDef) {

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -61,9 +61,9 @@ export class MapState implements IMapState {
   /** from north in degrees */
   rotation: number;
   /** current map projection */
-  proj?: Omit<IMapStateProjection, 'IProjDef'>;
+  proj: Required<Omit<IMapStateProjection, 'IProjDef'>>;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg: string = WebMercator, projFitOptions?: IProjFitOptions) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg?: string, projFitOptions?: IProjFitOptions) {
     const defaultOptions = {
       maxzoom: 0,
       minzoom: 0,
@@ -74,7 +74,7 @@ export class MapState implements IMapState {
     this.extent = extent;
     this.nativeExtent = nativeExtent;
     this.proj = {
-      epsg,
+      epsg: epsg || WebMercator,
       fitOptions: Object.assign({}, projFitOptions)
     }
     this.time = time;

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -1,3 +1,5 @@
+import { EPSG_3857_Def, WebMercator } from "./projections";
+
 export interface IMapCenter {
   lat: number;
   lon: number;
@@ -9,17 +11,29 @@ export interface IMapStateOptions {
   notifier?: 'user' | 'map';
 }
 
+export interface IProjOptions {
+  fitToProjectionExtent?: boolean
+  fitToBbox?: TGeoExtent
+  fitToNativeBbox?: TGeoExtent
+}
+
 export interface IMapState {
   zoom: number;
   center: IMapCenter;
   options?: IMapStateOptions;
+  /** WGS84: Extent */
   extent?: TGeoExtent;
+  /** Extent in the current map projection */
+  nativeExtent?: TGeoExtent;
   /** iso 8601 Datestring */
   time?: string;
   /** from nadir in degrees */
   viewAngle?: number;
   /** from north in degrees */
   rotation?: number;
+  /** EPSG of current map projection */
+  epsg?: string;
+  projOptions?: IProjOptions;
 }
 
 /**
@@ -34,15 +48,21 @@ export class MapState implements IMapState {
     lon: number;
   };
   options: IMapStateOptions;
+  /** WGS84: Extent */
   extent: TGeoExtent;
+  /** Extent in the current map projection */
+  nativeExtent: TGeoExtent;
   /** iso 8601 Datestring */
   time: string;
   /** from nadir in degrees */
   viewAngle: number;
   /** from north in degrees */
   rotation: number;
+  /** EPSG of current map projection */
+  epsg: string;
+  projOptions?: IProjOptions;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg: string = WebMercator, projOptions?: IProjOptions) {
     const defaultOptions = {
       maxzoom: 0,
       minzoom: 0,
@@ -51,10 +71,13 @@ export class MapState implements IMapState {
     this.zoom = zoom;
     this.center = center;
     this.extent = extent;
+    this.nativeExtent = nativeExtent;
+    this.epsg = epsg;
     this.time = time;
     this.viewAngle = viewAngle;
     this.rotation = rotation;
     this.options = Object.assign(defaultOptions, options);
+    this.projOptions = Object.assign({}, projOptions);
   }
 
 

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -11,7 +11,7 @@ export interface IMapStateOptions {
   notifier?: 'user' | 'map';
 }
 
-export interface IProjOptions {
+export interface IProjFitOptions {
   fitToProjectionExtent?: boolean
   fitToBbox?: TGeoExtent
   fitToNativeBbox?: TGeoExtent
@@ -31,15 +31,14 @@ export interface IMapState {
   viewAngle?: number;
   /** from north in degrees */
   rotation?: number;
-  /** EPSG of current map projection */
-  epsg?: string;
-  projOptions?: IProjOptions;
+  /** current map projection */
+  proj?: Omit<IMapStateProjection, 'IProjDef'>;
 }
 
 export interface IMapStateProjection {
   /** EPSG of current map projection */
   epsg?: string;
-  projOptions?: IProjOptions;
+  fitOptions?: IProjFitOptions;
   IProjDef?: IProjDef;
 }
 
@@ -65,11 +64,10 @@ export class MapState implements IMapState {
   viewAngle: number;
   /** from north in degrees */
   rotation: number;
-  /** EPSG of current map projection */
-  epsg: string;
-  projOptions?: IProjOptions;
+  /** current map projection */
+  proj?: Omit<IMapStateProjection, 'IProjDef'>;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg: string = WebMercator, projOptions?: IProjOptions) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg: string = WebMercator, projFitOptions?: IProjFitOptions) {
     const defaultOptions = {
       maxzoom: 0,
       minzoom: 0,
@@ -79,12 +77,14 @@ export class MapState implements IMapState {
     this.center = center;
     this.extent = extent;
     this.nativeExtent = nativeExtent;
-    this.epsg = epsg;
+    this.proj = {
+      epsg,
+      fitOptions: Object.assign({}, projFitOptions)
+    }
     this.time = time;
     this.viewAngle = viewAngle;
     this.rotation = rotation;
     this.options = Object.assign(defaultOptions, options);
-    this.projOptions = Object.assign({}, projOptions);
   }
 
 

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -36,6 +36,13 @@ export interface IMapState {
   projOptions?: IProjOptions;
 }
 
+export interface IMapStateProjection {
+  /** EPSG of current map projection */
+  epsg?: string;
+  projOptions?: IProjOptions;
+  IProjDef?: IProjDef;
+}
+
 /**
  * like ol.extent: minX, minY, maxX, maxY
  */

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -1,3 +1,4 @@
+import { TGeoExtent } from "@dlr-eoc/services-layers";
 import { EPSG_3857_Def, IProjDef, WebMercator } from "./projections";
 
 export interface IMapCenter {
@@ -41,11 +42,6 @@ export interface IMapStateProjection {
   fitOptions?: IProjFitOptions;
   IProjDef?: IProjDef;
 }
-
-/**
- * like ol.extent: minX, minY, maxX, maxY
- */
-export type TGeoExtent = [number, number, number, number] | [number, number, number, number, number, number];
 
 export class MapState implements IMapState {
   zoom: number;

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -1,4 +1,4 @@
-import { EPSG_3857_Def, WebMercator } from "./projections";
+import { EPSG_3857_Def, IProjDef, WebMercator } from "./projections";
 
 export interface IMapCenter {
   lat: number;

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -1,0 +1,52 @@
+export interface IProjDef {
+    code: string; // e.g.: "EPSG:3857"
+    proj4js: string; // ' proj4 string, e.g.: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"
+    title: string; // projection title shown on switch, e.g.: "Spherical Mercator",
+    extent: [number, number, number, number]; // projection extent in projected coordinates, e.g.: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
+    worldExtent: [number, number, number, number]; // projection extent in geographical coordinates, e.g.:[-180.0, -85.06, 180.0, 85.06],
+    global: true | false; // whether is global or local projection
+    units: 'radians' | 'degrees' | 'ft' | 'm' | 'pixels' | 'tile-pixels' | 'us-ft';
+}
+
+export const WebMercator = 'EPSG:3857';
+export const WGS84 = 'EPSG:4326';
+
+export const EPSG_3995_Def: IProjDef = {
+    code: 'EPSG:3995',
+    proj4js: '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
+    title: 'Arctic Polar Stereographic',
+    extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
+    worldExtent: [-180.0, 60.0, 180.0, 90.0],
+    global: true,
+    units: 'm'
+};
+
+export const EPSG_3031_Def: IProjDef = {
+    code: `EPSG:3031`,
+    proj4js: '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
+    title: 'Antarctic Polar Stereographic',
+    extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
+    worldExtent: [-180.0, -90.0, 180.0, -60.0],
+    global: true,
+    units: 'm'
+};
+
+export const EPSG_3857_Def: IProjDef = {
+    code: WebMercator,
+    proj4js: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
+    title: 'Spherical Mercator',
+    extent: [-20037508.34, -20048966.1, 20037508.34, 20048966.1],
+    worldExtent: [-180.0, -85.06, 180.0, 85.06],
+    global: true,
+    units: 'm'
+};
+
+export const EPSG_4326_Def: IProjDef = {
+    code: WGS84,
+    proj4js: '+proj=longlat +datum=WGS84 +no_defs +type=crs',
+    title: 'WGS 84',
+    extent: [-180.0, -90.0, 180.0, 90.0],
+    worldExtent: [-180.0, -90.0, 180.0, 90.0],
+    global: true,
+    units: 'degrees'
+};

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -17,7 +17,7 @@ export const EPSG_3995_Def: IProjDef = {
     title: 'Arctic Polar Stereographic',
     extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
     worldExtent: [-180.0, 60.0, 180.0, 90.0],
-    global: true,
+    global: false,
     units: 'm'
 };
 
@@ -27,7 +27,7 @@ export const EPSG_3031_Def: IProjDef = {
     title: 'Antarctic Polar Stereographic',
     extent: [-3299207.53, -3333134.03, 3299207.53, 3333134.03],
     worldExtent: [-180.0, -90.0, 180.0, -60.0],
-    global: true,
+    global: false,
     units: 'm'
 };
 

--- a/projects/services-map-state/src/public-api.ts
+++ b/projects/services-map-state/src/public-api.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './lib/types/map-state';
+export * from './lib/types/projections';
 export * from './lib/map-state.service';

--- a/projects/services-ogc/package.json
+++ b/projects/services-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/services-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This module bundles our clients for OGC standards. E.g. parse OWS Context JSON, WMS, WMTS or WPS.",
@@ -20,11 +20,11 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.7",
-    "@dlr-eoc/services-util-store": "16.0.0-next.7",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
-    "@dlr-eoc/services-map-state": "16.0.0-next.7",
-    "@dlr-eoc/utils-ogc": "16.0.0-next.7",
+    "@dlr-eoc/services-layers": "16.0.0-next.8",
+    "@dlr-eoc/services-util-store": "16.0.0-next.8",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.8",
+    "@dlr-eoc/services-map-state": "16.0.0-next.8",
+    "@dlr-eoc/utils-ogc": "16.0.0-next.8",
     "w3c-schemas": "^1.4.0",
     "ogc-schemas": "^2.6.1",
     "ol": "^v10.8.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/shared-assets": "16.0.0-next.7",
+    "@dlr-eoc/shared-assets": "16.0.0-next.8",
     "proj4": "^2.17.0",
     "terser": "^5.39.2"
   }

--- a/projects/services-ogc/package.json
+++ b/projects/services-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/services-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This module bundles our clients for OGC standards. E.g. parse OWS Context JSON, WMS, WMTS or WPS.",
@@ -20,11 +20,11 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.5",
-    "@dlr-eoc/services-util-store": "16.0.0-next.5",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.5",
-    "@dlr-eoc/services-map-state": "16.0.0-next.5",
-    "@dlr-eoc/utils-ogc": "16.0.0-next.5",
+    "@dlr-eoc/services-layers": "16.0.0-next.6",
+    "@dlr-eoc/services-util-store": "16.0.0-next.6",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
+    "@dlr-eoc/services-map-state": "16.0.0-next.6",
+    "@dlr-eoc/utils-ogc": "16.0.0-next.6",
     "w3c-schemas": "^1.4.0",
     "ogc-schemas": "^2.6.1",
     "ol": "^v10.8.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/shared-assets": "16.0.0-next.5",
+    "@dlr-eoc/shared-assets": "16.0.0-next.6",
     "proj4": "^2.17.0",
     "terser": "^5.39.2"
   }

--- a/projects/services-ogc/package.json
+++ b/projects/services-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/services-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This module bundles our clients for OGC standards. E.g. parse OWS Context JSON, WMS, WMTS or WPS.",
@@ -20,11 +20,11 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0-next.6",
-    "@dlr-eoc/services-util-store": "16.0.0-next.6",
-    "@dlr-eoc/base-layers-raster": "16.0.0-next.6",
-    "@dlr-eoc/services-map-state": "16.0.0-next.6",
-    "@dlr-eoc/utils-ogc": "16.0.0-next.6",
+    "@dlr-eoc/services-layers": "16.0.0-next.7",
+    "@dlr-eoc/services-util-store": "16.0.0-next.7",
+    "@dlr-eoc/base-layers-raster": "16.0.0-next.7",
+    "@dlr-eoc/services-map-state": "16.0.0-next.7",
+    "@dlr-eoc/utils-ogc": "16.0.0-next.7",
     "w3c-schemas": "^1.4.0",
     "ogc-schemas": "^2.6.1",
     "ol": "^v10.8.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^19.2.19",
-    "@dlr-eoc/shared-assets": "16.0.0-next.6",
+    "@dlr-eoc/shared-assets": "16.0.0-next.7",
     "proj4": "^2.17.0",
     "terser": "^5.39.2"
   }

--- a/projects/services-ogc/src/lib/owc/owc-json.service.ts
+++ b/projects/services-ogc/src/lib/owc/owc-json.service.ts
@@ -34,9 +34,9 @@ import {
   IWmtsParams,
   TVectorLayertype,
   StackedLayer,
-  IStackedLayerOptions
+  IStackedLayerOptions,
+  TGeoExtent
 } from '@dlr-eoc/services-layers';
-import { TGeoExtent } from '@dlr-eoc/services-map-state';
 import { WmtsClientService } from '../wmts/wmtsclient.service';
 import { of, Observable, forkJoin, concat } from 'rxjs';
 import { filter, map } from 'rxjs/operators';

--- a/projects/services-util-store/package.json
+++ b/projects/services-util-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-util-store",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/services-util-store/package.json
+++ b/projects/services-util-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-util-store",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/services-util-store/package.json
+++ b/projects/services-util-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-util-store",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/shared-assets/package.json
+++ b/projects/shared-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/shared-assets",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "main": "index",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/shared-assets/package.json
+++ b/projects/shared-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/shared-assets",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "main": "index",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/shared-assets/package.json
+++ b/projects/shared-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/shared-assets",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "main": "index",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/utilities/package.json
+++ b/projects/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utilities",
   "main": "src/public-api",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities.",

--- a/projects/utilities/package.json
+++ b/projects/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utilities",
   "main": "src/public-api",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities.",

--- a/projects/utilities/package.json
+++ b/projects/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utilities",
   "main": "src/public-api",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities.",

--- a/projects/utils-browser/package.json
+++ b/projects/utils-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-browser",
   "main": "src/public-api",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities like download data as blob and Paper layout.",

--- a/projects/utils-browser/package.json
+++ b/projects/utils-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-browser",
   "main": "src/public-api",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities like download data as blob and Paper layout.",

--- a/projects/utils-browser/package.json
+++ b/projects/utils-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-browser",
   "main": "src/public-api",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities like download data as blob and Paper layout.",

--- a/projects/utils-maps/package.json
+++ b/projects/utils-maps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-maps",
   "main": "src/public-api",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities for OpenLayers and WebGL.",

--- a/projects/utils-maps/package.json
+++ b/projects/utils-maps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-maps",
   "main": "src/public-api",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities for OpenLayers and WebGL.",

--- a/projects/utils-maps/package.json
+++ b/projects/utils-maps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-maps",
   "main": "src/public-api",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities for OpenLayers and WebGL.",

--- a/projects/utils-ogc/package.json
+++ b/projects/utils-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.7",
+  "version": "16.0.0-next.8",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library bundles our clients for OGC standards. The long-term-strategy is to make all services in `@dlr-eoc/services-ogc` independent of angular and move them here.",

--- a/projects/utils-ogc/package.json
+++ b/projects/utils-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.5",
+  "version": "16.0.0-next.6",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library bundles our clients for OGC standards. The long-term-strategy is to make all services in `@dlr-eoc/services-ogc` independent of angular and move them here.",

--- a/projects/utils-ogc/package.json
+++ b/projects/utils-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-ogc",
   "main": "src/public-api",
-  "version": "16.0.0-next.6",
+  "version": "16.0.0-next.7",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library bundles our clients for OGC standards. The long-term-strategy is to make all services in `@dlr-eoc/services-ogc` independent of angular and move them here.",

--- a/scripts/library/CHANGELOG.md
+++ b/scripts/library/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [3.0.5]
+
+### Bug Fixes
+- fix prepare publish for GitHub Packages.
+
 # [3.0.4]
 
 ### Bug Fixes

--- a/scripts/library/index.ts
+++ b/scripts/library/index.ts
@@ -216,6 +216,14 @@ function updateBuildPackages(registry?: string) {
           json.repository.url = repositoryUrl;
           json.repository.type = `git`;
         }
+
+        // GitHub Packages now requires publishConfig.registry in new npm cli
+        if (registry && registry.includes('npm.pkg.github.com')) {
+          const scopeReg = `${PACKAGE_SCOPE}:registry`;
+          const publishConfig = {};
+          publishConfig[scopeReg] = registry;
+          json.publishConfig = publishConfig;
+        }
         return json;
       });
 

--- a/scripts/library/package.json
+++ b/scripts/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-libraries-scripts",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This package contains a few scripts to build and test angular libraries.",

--- a/scripts/library/utils.ts
+++ b/scripts/library/utils.ts
@@ -170,15 +170,14 @@ export function updatePackageJson(path: string, cb: (json: IPackageJSON) => IPac
 
 export function createNpmrc(path: string, scope: string, registry = 'https://npm.pkg.github.com') {
   let npmrc = `
-    ${scope}:registry=${registry}:_authToken=${process.env.AUTH_TOKEN}
+${scope}:registry=${registry}:_authToken=${process.env.AUTH_TOKEN}
 loglevel = "verbose"`;
 
   /** https://github.com/actions/setup-node/blob/v6.2.0/src/authutil.ts */
-  if(registry.includes('npm.pkg.github.com')){
-    npmrc = `
-    ${registry.replace(/(^\w+:|^)/, '')}:_authToken=${process.env.AUTH_TOKEN}
-${scope}:registry=${registry}
-loglevel = "verbose"`
+  if (registry.includes('npm.pkg.github.com')) {
+    npmrc = `${scope}:registry=${registry}
+${registry.replace(/(^\w+:|^)/, '')}:_authToken=${process.env.NODE_AUTH_TOKEN}
+loglevel=verbose`;
   }
 
   try {
@@ -385,7 +384,7 @@ export function getSortedProjects(projects: ICustomWorkspaceProject[], packageSc
   /** An array of directed edges describing a graph e.g. edge1   */
   // maybe check other toposort libs https://www.npmjs.com/search?page=0&q=toposort&sortBy=dependent_count
   const flattdeps = toposort(edges).reverse();
-  
+
   // check for deps without edges and push them in the array
   if (Array.isArray(filterPN) && filterPN.length) {
     filterPN.forEach(p => {

--- a/scripts/library/utils.ts
+++ b/scripts/library/utils.ts
@@ -169,10 +169,17 @@ export function updatePackageJson(path: string, cb: (json: IPackageJSON) => IPac
 }
 
 export function createNpmrc(path: string, scope: string, registry = 'https://npm.pkg.github.com') {
-  /** https://github.com/actions/setup-node/blob/v6.2.0/src/authutil.ts */
-  const npmrc = `
+  let npmrc = `
     ${scope}:registry=${registry}:_authToken=${process.env.AUTH_TOKEN}
-    loglevel = "verbose"`;
+loglevel = "verbose"`;
+
+  /** https://github.com/actions/setup-node/blob/v6.2.0/src/authutil.ts */
+  if(registry.includes('npm.pkg.github.com')){
+    npmrc = `
+    ${registry.replace(/(^\w+:|^)/, '')}:_authToken=${process.env.AUTH_TOKEN}
+${scope}:registry=${registry}
+loglevel = "verbose"`
+  }
 
   try {
     if (path) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #204 and ci for publish GitHub Packages is not working.


## What is the new behavior?

The package `@dlr-eoc/services-map-state` can now register and set projection, which has already been implemented in `@dlr-eoc/map-ol`. The packages `@dlr-eoc/map-cesium` and `@dlr-eoc/map-maplibre` only use a small part of it to set the current `MapState`.

- [feat(services-map-state): export basic projection helpers and definitions](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/f7ff8bd6a0541890f146c0b6fe0b6b3d5aae7303)
- [feat(services-map-state): add functionality to setProjection and nativeExtent](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/0403053cad583a7bd31633998f825d2710ab5457)
- [feat(services-map-state): export interface for MapStateProjection](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/58a36965009ae428412406d9a21bc51872d935a1)
- [feat: add registered projections in services-map-state and adjust map-ol to use it](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/c9a8fc3a6e3571ccc603272f4f8b0274758c9468)


## Does this PR introduce a breaking change?

- [x] Yes

- [BREAKING CHANGE(ngx-ukis-ui-clarity): projection-switch and mouse-pos…](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/9208d12ab56bb63df85550d20f0545e59bf0eed1)
- [BREAKING CHANGE(map-cesium): not used option geographic removed from …](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/7a9daa21fb4a2a52960f5164c212f25e62932d30)
- [BREAKING CHANGE(map-ol): params of service.setProjection changed to r…](https://github.com/dlr-eoc/ukis-frontend-libraries/commit/71fbdcd69fa0318c4ab8c75f2613b766bf4f3c41)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
- `@dlr-eoc/services-map-state`
- `@dlr-eoc/ngx-ukis-ui-clarity`
- `@dlr-eoc/map-ol`
- `@dlr-eoc/map-maplibre`
- `@dlr-eoc/map-cesium`
- `demo-maps` 


Unfortunately, the tests in Chrome's headless do not work now and this fix [ci: try to fix WebGL error in actions test](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/288/commits/9a49fd78956a04be57fb7fb0d0c5e38f88f965f0) was unsuccessful.
