### PR TITLE
Change IProjDef and adjustBBoxAxis function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **@dlr-eoc/services-map-state**
  - Allow to use `projjson` in `IProjDef`.
  - Export `EPSG_3035_Def`
+ - Export function `adjustBBoxAxis` and `adjustBBoxAxisToEnu` for convert to `enu`.
 
 * **@dlr-eoc/map-ol:**
  - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * **@dlr-eoc/map-ol:**
  - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.
 
+ 
+### Bug Fixes
+* **@dlr-eoc/ngx-ukis-ui-clarity:**
+ - Can zoom to `nativeBbox` for `LayerentryComponent` and `LayerentryGroupComponent`.
+
 
 # [16.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v16.0.0) (2026-05-29) (update dependencies, new library ngx-ukis-ui-clarity and ngx-ukis-utilities, replace core-ui)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * **@dlr-eoc/ngx-ukis-ui-clarity:**
  - Can zoom to `nativeBbox` for `LayerentryComponent` and `LayerentryGroupComponent`.
 
+* **@dlr-eoc/map-ol:**
+ - Try to udjust (native) bbox to enu before ol `setExtent`. This tries to fixes native bbox axis from wms 1.3.0. See `adjustBBoxAxisToEnu`.
+
 
 # [16.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v16.0.0) (2026-05-29) (update dependencies, new library ngx-ukis-ui-clarity and ngx-ukis-utilities, replace core-ui)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
  - Can zoom to `nativeBbox` for `LayerentryComponent` and `LayerentryGroupComponent`.
 
 * **@dlr-eoc/map-ol:**
- - Try to udjust (native) bbox to enu before ol `setExtent`. This tries to fixes native bbox axis from wms 1.3.0. See `adjustBBoxAxisToEnu`.
+ - Transform extent in `setLayerExtentAfterProjection` if nativeBbox.epsg is not new epsg or try to use old extent.
 
 
 # [16.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v16.0.0) (2026-05-29) (update dependencies, new library ngx-ukis-ui-clarity and ngx-ukis-utilities, replace core-ui)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Features
+* **@dlr-eoc/services-map-state**
+ - Allow to use `projjson` in `IProjDef`.
+
 # [16.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v16.0.0) (2026-05-29) (update dependencies, new library ngx-ukis-ui-clarity and ngx-ukis-utilities, replace core-ui)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * **@dlr-eoc/services-map-state**
  - Allow to use `projjson` in `IProjDef`.
 
+* **@dlr-eoc/map-ol:**
+ - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.
+
+
 # [16.0.0](https://github.com/dlr-eoc/ukis-frontend-libraries/tree/v16.0.0) (2026-05-29) (update dependencies, new library ngx-ukis-ui-clarity and ngx-ukis-utilities, replace core-ui)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * **@dlr-eoc/services-map-state**
  - Allow to use `projjson` in `IProjDef`.
  - Export `EPSG_3035_Def`
- - Export function `adjustBBoxAxis` and `adjustBBoxAxisToEnu` for convert to `enu`.
+ - Export function `getProj4Defs(projDef: IProjDef)`, `adjustBBoxAxis(bbox: [number, number, number, number], axis: AxisType)` and `adjustBBoxAxisToEnu(bbox: [number, number, number, number], proj?: TepsgCode | IProjDef, axis?: AxisType)` for convert to `enu`. Use this for `nativeBbox` get from wms 1.3.0. This tries to fixes native bbox axis from wms 1.3.0.
 
 * **@dlr-eoc/map-ol:**
  - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Features
 * **@dlr-eoc/services-map-state**
  - Allow to use `projjson` in `IProjDef`.
+ - Export `EPSG_3035_Def`
 
 * **@dlr-eoc/map-ol:**
  - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ukis-frontend-libraries",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -22341,10 +22341,10 @@
     },
     "projects/base-layers-raster": {
       "name": "@dlr-eoc/base-layers-raster",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22355,10 +22355,10 @@
     },
     "projects/cookie-alert": {
       "name": "@dlr-eoc/cookie-alert",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-util-store": "16.0.0",
+        "@dlr-eoc/services-util-store": "16.0.1-next.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22371,13 +22371,13 @@
       }
     },
     "projects/demo-auth": {
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/cookie-alert": "16.0.0",
-        "@dlr-eoc/map-ol": "16.0.0",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/cookie-alert": "16.0.1-next.0",
+        "@dlr-eoc/map-ol": "16.0.1-next.0",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.0"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
@@ -22394,18 +22394,18 @@
       }
     },
     "projects/demo-maps": {
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/map-cesium": "16.0.0",
-        "@dlr-eoc/map-maplibre": "16.0.0",
-        "@dlr-eoc/map-ol": "16.0.0",
-        "@dlr-eoc/map-three": "16.0.0",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0",
-        "@dlr-eoc/services-ogc": "16.0.0",
-        "@dlr-eoc/shared-assets": "16.0.0",
-        "@dlr-eoc/utils-maps": "16.0.0"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/map-cesium": "16.0.1-next.0",
+        "@dlr-eoc/map-maplibre": "16.0.1-next.0",
+        "@dlr-eoc/map-ol": "16.0.1-next.0",
+        "@dlr-eoc/map-three": "16.0.1-next.0",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.0",
+        "@dlr-eoc/services-ogc": "16.0.1-next.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0",
+        "@dlr-eoc/utils-maps": "16.0.1-next.0"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
@@ -22425,18 +22425,18 @@
     },
     "projects/map-cesium": {
       "name": "@dlr-eoc/map-cesium",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/engine": "^22.3.0",
         "@cesium/widgets": "^14.3.0",
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/shared-assets": "16.0.0"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0"
       },
       "peerDependencies": {
         "@angular/common": "^21.2.14",
@@ -22446,19 +22446,19 @@
     },
     "projects/map-maplibre": {
       "name": "@dlr-eoc/map-maplibre",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
-        "@dlr-eoc/utilities": "16.0.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
+        "@dlr-eoc/utilities": "16.0.1-next.0",
         "@mapbox/togeojson": "0.16.2",
         "maplibre-gl": "^5.24.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/shared-assets": "16.0.0"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0"
       },
       "peerDependencies": {
         "@angular/common": "^21.2.14",
@@ -22468,12 +22468,12 @@
     },
     "projects/map-ol": {
       "name": "@dlr-eoc/map-ol",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
-        "@dlr-eoc/utils-maps": "16.0.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
+        "@dlr-eoc/utils-maps": "16.0.1-next.0",
         "ol": "^v10.9.0",
         "ol-mapbox-style": "^13.2.1",
         "proj4": "^2.20.8",
@@ -22481,8 +22481,8 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/shared-assets": "16.0.0",
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22493,13 +22493,13 @@
     },
     "projects/map-three": {
       "name": "@dlr-eoc/map-three",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/map-ol": "16.0.0",
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
-        "@dlr-eoc/utils-maps": "16.0.0",
+        "@dlr-eoc/map-ol": "16.0.1-next.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
+        "@dlr-eoc/utils-maps": "16.0.1-next.0",
         "proj4": "^2.20.8",
         "three": "^0.176.0",
         "tslib": "^2.6.3"
@@ -22515,7 +22515,7 @@
     },
     "projects/ngx-ukis-ui-clarity": {
       "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-devkit/core": "^21.2.13",
@@ -22539,10 +22539,10 @@
         "@angular/router": "^21.2.14",
         "@clr/angular": "^18.1.0",
         "@clr/ui": "^18.1.0",
-        "@dlr-eoc/map-ol": "16.0.0",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0",
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
+        "@dlr-eoc/map-ol": "16.0.1-next.0",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
         "jsonc-parser": "^3.3.1",
         "ol": "^v10.9.0",
         "proj4": "^2.20.8",
@@ -22593,7 +22593,7 @@
     },
     "projects/ngx-ukis-utilities": {
       "name": "@dlr-eoc/ngx-ukis-utilities",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22607,15 +22607,15 @@
     },
     "projects/services-layers": {
       "name": "@dlr-eoc/services-layers",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.0",
-        "@dlr-eoc/shared-assets": "16.0.0",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22626,10 +22626,10 @@
     },
     "projects/services-map-state": {
       "name": "@dlr-eoc/services-map-state",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22644,14 +22644,14 @@
     },
     "projects/services-ogc": {
       "name": "@dlr-eoc/services-ogc",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.0",
-        "@dlr-eoc/services-layers": "16.0.0",
-        "@dlr-eoc/services-map-state": "16.0.0",
-        "@dlr-eoc/services-util-store": "16.0.0",
-        "@dlr-eoc/utils-ogc": "16.0.0",
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+        "@dlr-eoc/services-layers": "16.0.1-next.0",
+        "@dlr-eoc/services-map-state": "16.0.1-next.0",
+        "@dlr-eoc/services-util-store": "16.0.1-next.0",
+        "@dlr-eoc/utils-ogc": "16.0.1-next.0",
         "jsonix": "^3.0.0",
         "luxon": "^3.7.2",
         "ogc-schemas": "^2.6.1",
@@ -22662,7 +22662,7 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/shared-assets": "16.0.0",
+        "@dlr-eoc/shared-assets": "16.0.1-next.0",
         "proj4": "^2.20.8",
         "terser": "^5.39.2",
         "zone.js": "~0.15.1"
@@ -22675,7 +22675,7 @@
     },
     "projects/services-util-store": {
       "name": "@dlr-eoc/services-util-store",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",
@@ -22692,13 +22692,13 @@
     },
     "projects/shared-assets": {
       "name": "@dlr-eoc/shared-assets",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
     "projects/utilities": {
       "name": "@dlr-eoc/utilities",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22710,7 +22710,7 @@
     },
     "projects/utils-browser": {
       "name": "@dlr-eoc/utils-browser",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/core": "^21.2.14",
@@ -22720,7 +22720,7 @@
     },
     "projects/utils-maps": {
       "name": "@dlr-eoc/utils-maps",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "delaunator": "^5.0.1",
@@ -22735,7 +22735,7 @@
     },
     "projects/utils-ogc": {
       "name": "@dlr-eoc/utils-ogc",
-      "version": "16.0.0",
+      "version": "16.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonix": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "projectsScope": "@dlr-eoc/",

--- a/projects/base-layers-raster/package.json
+++ b/projects/base-layers-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/base-layers-raster",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -13,7 +13,7 @@
     "OSM"
   ],
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/cookie-alert/package.json
+++ b/projects/cookie-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/cookie-alert",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -16,7 +16,7 @@
     "@angular/core": "^21.2.14"
   },
   "dependencies": {
-    "@dlr-eoc/services-util-store": "16.0.0",
+    "@dlr-eoc/services-util-store": "16.0.1-next.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/demo-auth/package.json
+++ b/projects/demo-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-auth",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,10 +21,10 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0",
-    "@dlr-eoc/cookie-alert": "16.0.0",
-    "@dlr-eoc/base-layers-raster": "16.0.0"
+    "@dlr-eoc/map-ol": "16.0.1-next.0",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.0",
+    "@dlr-eoc/cookie-alert": "16.0.1-next.0",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/package.json
+++ b/projects/demo-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-maps",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -22,15 +22,15 @@
     "proj4": "^2.20.8"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.0",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.0",
-    "@dlr-eoc/base-layers-raster": "16.0.0",
-    "@dlr-eoc/map-three": "16.0.0",
-    "@dlr-eoc/utils-maps": "16.0.0",
-    "@dlr-eoc/services-ogc": "16.0.0",
-    "@dlr-eoc/shared-assets": "16.0.0",
-    "@dlr-eoc/map-cesium": "16.0.0",
-    "@dlr-eoc/map-maplibre": "16.0.0"
+    "@dlr-eoc/map-ol": "16.0.1-next.0",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.0",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+    "@dlr-eoc/map-three": "16.0.1-next.0",
+    "@dlr-eoc/utils-maps": "16.0.1-next.0",
+    "@dlr-eoc/services-ogc": "16.0.1-next.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0",
+    "@dlr-eoc/map-cesium": "16.0.1-next.0",
+    "@dlr-eoc/map-maplibre": "16.0.1-next.0"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/src/app/route-components/route-example-events/map.utils.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-events/map.utils.ts
@@ -1,4 +1,5 @@
 import { TGeoExtent } from '@dlr-eoc/services-layers';
+import { TepsgCode } from '@dlr-eoc/services-map-state';
 import olFeature from 'ol/Feature';
 import olPolygon from 'ol/geom/Polygon';
 import { containsXY } from 'ol/extent';
@@ -10,7 +11,7 @@ import { buffer } from 'ol/extent';
  * https://github.com/Turfjs/turf/blob/master/packages/turf-rectangle-grid/index.ts
  * returns  olFeature<any>[]
  */
-export const regularGrid = (bbox: TGeoExtent, cellSizeDeg: number, zoom: number, mapEPSG: string, mapExtent: TGeoExtent) => {
+export const regularGrid = (bbox: TGeoExtent, cellSizeDeg: number, zoom: number, mapEPSG: TepsgCode, mapExtent: TGeoExtent) => {
   /** olFeature */
   const features: olFeature<olPolygon>[] = [];
 

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { LayersService, RasterLayer, TGeoExtent, VectorLayer } from '@dlr-eoc/services-layers';
-import { EPSG_3031_Def, EPSG_3995_Def, IProjDef, MapStateService, EPSG_3857_Def, EPSG_4326_Def } from '@dlr-eoc/services-map-state';
+import { EPSG_3031_Def, EPSG_3995_Def, IProjDef, MapStateService, EPSG_3857_Def, EPSG_4326_Def, EPSG_3035_Def } from '@dlr-eoc/services-map-state';
 import { MapOlService, IMapControls, MapOlComponent } from '@dlr-eoc/map-ol';
 import { OsmTileLayer } from '@dlr-eoc/base-layers-raster';
 
@@ -66,7 +66,7 @@ export class RouteMap2Component implements OnInit {
       units: 'm'
     }
 
-    this.projections = [EPSG_3857_Def, EPSG_3995_Def, EPSG_3031_Def, SwissCH1903, ESRI_53034, ETRS89_UTM_37N, EPSG_4326_Def];
+    this.projections = [EPSG_3857_Def, EPSG_3995_Def, EPSG_3031_Def, SwissCH1903, ESRI_53034, ETRS89_UTM_37N, EPSG_4326_Def, EPSG_3035_Def];
     /** 
        * set map extent or IMapState (zoom, center...) with the MapStateService 
        * Check if the Extent is valid for the set projection.
@@ -93,7 +93,7 @@ export class RouteMap2Component implements OnInit {
   addOverlays() {
     const osm_layer = new OsmTileLayer({
       removable: true,
-      legendImg: null,
+      legendImg: undefined,
       visible: true,
       id: 'osm'
     });

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { LayersService, RasterLayer, TGeoExtent, VectorLayer } from '@dlr-eoc/services-layers';
-import { EPSG_3031_Def, EPSG_3995_Def, IProjDef, MapStateService, EPSG_3857_Def, EPSG_4326_Def, EPSG_3035_Def } from '@dlr-eoc/services-map-state';
+import { EPSG_3031_Def, EPSG_3995_Def, IProjDef, MapStateService, EPSG_3857_Def, EPSG_4326_Def, EPSG_3035_Def, adjustBBoxAxisToEnu } from '@dlr-eoc/services-map-state';
 import { MapOlService, IMapControls, MapOlComponent } from '@dlr-eoc/map-ol';
 import { OsmTileLayer } from '@dlr-eoc/base-layers-raster';
 
@@ -132,11 +132,11 @@ export class RouteMap2Component implements OnInit {
         55.169891337305664
       ],
       nativeBbox: {
-        epsg: 'EPSG:3035',
-        bbox: [2672950,
-          4016550,
-          3562840,
-          4684770]
+        epsg: EPSG_3035_Def.code, // the axis must be defined in the IProjDef
+        // wms 1.3.0 <BoundingBox CRS="EPSG:3035" minx="2672950.0" miny="4016550.0" maxx="3562840.0" maxy="4684770.0"/>
+        bbox: adjustBBoxAxisToEnu([2672950, 4016550, 3562840, 4684770], EPSG_3035_Def)
+        // wms: 1.1.1 <BoundingBox SRS="EPSG:3035" minx="4016550.0" miny="2672950.0" maxx="4684770.0" maxy="3562840.0"/>
+        /* bbox: [4016550, 2672950, 4684770, 3562840] */
       }
     });
 

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -113,6 +113,33 @@ export class RouteMap2Component implements OnInit {
       legendImg: ''
     });
 
+    const fcclLayer = new RasterLayer({
+      type: 'wms',
+      url: 'https://geoservice.dlr.de/eoc/land/wms',
+      name: 'FCCL DE P1M',
+      id: 'FCCL_DE_P1M',
+      attribution: ', <a href="https://geoservice.dlr.de/web/datasets/fccl" target="_blank">FCCL</a>',
+      description: 'This raster dataset shows forest canopy cover loss (FCCL) in Germany at a monthly resolution from September 2017 to October 2025',
+      params: {
+        layers: 'FCCL_DE_P1M'
+      },
+      visible: false,
+      legendImg: undefined,
+      bbox: [
+        5.230971659340296,
+        47.06431450392907,
+        15.694865911359667,
+        55.169891337305664
+      ],
+      nativeBbox: {
+        epsg: 'EPSG:3035',
+        bbox: [2672950,
+          4016550,
+          3562840,
+          4684770]
+      }
+    });
+
     const vectorLayer = new VectorLayer({
       id: 'geojson_test',
       name: 'GeoJSON Vector Layer',
@@ -240,7 +267,7 @@ export class RouteMap2Component implements OnInit {
       }
     })
 
-    const overlays = [osm_layer, gufLayer, vectorLayer, TanDEMPolarDEM, vectorLayerPolar];
+    const overlays = [osm_layer, gufLayer, vectorLayer, TanDEMPolarDEM, vectorLayerPolar, fcclLayer];
     overlays.map(layer => this.layersSvc.addLayer(layer, 'Layers'));
   }
 

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-cesium",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,15 +19,15 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/services-layers": "16.0.0",
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
     "@cesium/engine": "^22.3.0",
     "@cesium/widgets": "^14.3.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0",
-    "@dlr-eoc/shared-assets": "16.0.0"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0"
   },
   "sideEffects": false
 }

--- a/projects/map-cesium/src/lib/map-cesium.service.ts
+++ b/projects/map-cesium/src/lib/map-cesium.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 import { Layer, VectorLayer, CustomLayer, RasterLayer, WmtsLayer, WmsLayer, TGeoExtent, TmsLayertype, WmtsLayertype, WmsLayertype, XyzLayertype, IListMatrixSet, TFiltertypesUncap, TFiltertypes } from '@dlr-eoc/services-layers';
 
 import { ICesiumControls } from './map-cesium.component';
-import { Cartesian3, Cesium3DTileStyle, Cesium3DTileset, CesiumTerrainProvider, Color, Credit, DataSource, EllipsoidTerrainProvider, GeoJsonDataSource, I3SDataProvider, ImageryLayer, Ion, JulianDate, KmlDataSource, Rectangle, TileMapServiceImageryProvider, TimeIntervalCollection, UrlTemplateImageryProvider, WebMapServiceImageryProvider, WebMapTileServiceImageryProvider, WebMercatorTilingScheme, Math as CesiumMath, BillboardGraphics} from '@cesium/engine';
+import { Cartesian3, Cesium3DTileStyle, Cesium3DTileset, CesiumTerrainProvider, Color, Credit, DataSource, EllipsoidTerrainProvider, GeoJsonDataSource, I3SDataProvider, ImageryLayer, Ion, JulianDate, KmlDataSource, Rectangle, TileMapServiceImageryProvider, TimeIntervalCollection, UrlTemplateImageryProvider, WebMapServiceImageryProvider, WebMapTileServiceImageryProvider, WebMercatorTilingScheme, Math as CesiumMath, BillboardGraphics } from '@cesium/engine';
 import { Viewer } from '@cesium/widgets';
-import { IMapCenter, WebMercator } from '@dlr-eoc/services-map-state';
+import { IMapCenter, WebMercator, TepsgCode } from '@dlr-eoc/services-map-state';
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes
 
@@ -31,7 +31,7 @@ export class MapCesiumService {
   private terrainLayerGroup = new Map<string, boolean>(); //Map for terrain containing layerID and visibility
   private tilesetLayerGroup = new Map<string, Cesium3DTileset>(); //Map for 3D tilesets containing layerID and viewer handler
 
-  public EPSG: string;
+  public EPSG: TepsgCode;
 
   //Time objects
   public cesiumCurrentTime = JulianDate.now();
@@ -1069,81 +1069,82 @@ export class MapCesiumService {
             }
           }
         }
-        }
+      }
     }
 
   }
 
   public updateDataSourceZIndex(layers: Layer[], filtertype: Tgroupfiltertype) {
     const dataSourceCollection = this.viewer.dataSources;
-    if(dataSourceCollection.length>1){
-    const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
+    if (dataSourceCollection.length > 1) {
+      const lowerType = filtertype.toLowerCase() as Tgroupfiltertype;
       if (lowerType === 'baselayers') {
         for (const layer of layers) {
-        if (this.baseLayerDataSourceGroup.has(layer.id)) {
-          const viewerLayer = this.baseLayerDataSourceGroup.get(layer.id);
-          if (viewerLayer) {
-            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
-            const layerIndex = layers.indexOf(layer);
-            if (cesiumIndex !== layerIndex && cesiumIndex >= 0) {
-              const diffIndex = cesiumIndex - layerIndex;
-              if (diffIndex < 0) {
-                // Move layer up in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.raise(viewerLayer);
-                }
-              } else if (diffIndex > 0) {
-                // Move layer down in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.lower(viewerLayer);
+          if (this.baseLayerDataSourceGroup.has(layer.id)) {
+            const viewerLayer = this.baseLayerDataSourceGroup.get(layer.id);
+            if (viewerLayer) {
+              const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+              const layerIndex = layers.indexOf(layer);
+              if (cesiumIndex !== layerIndex && cesiumIndex >= 0) {
+                const diffIndex = cesiumIndex - layerIndex;
+                if (diffIndex < 0) {
+                  // Move layer up in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.raise(viewerLayer);
+                  }
+                } else if (diffIndex > 0) {
+                  // Move layer down in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.lower(viewerLayer);
+                  }
                 }
               }
             }
-          }
           }
         }
       } else if (lowerType === 'layers') {
         for (const layer of layers) {
-        if (this.standardLayerDataSourceGroup.has(layer.id)) {
-          const viewerLayer = this.standardLayerDataSourceGroup.get(layer.id);
-          if (viewerLayer) {
-            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
-            const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers');
-            if (cesiumIndex !== layerIndex && cesiumIndex >= 0) {
-              const diffIndex = cesiumIndex - layerIndex;
-              if (diffIndex < 0) {
-                // Move layer up in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.raise(viewerLayer);
-                }
-              } else if (diffIndex > 0) {
-                // Move layer down in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.lower(viewerLayer);
+          if (this.standardLayerDataSourceGroup.has(layer.id)) {
+            const viewerLayer = this.standardLayerDataSourceGroup.get(layer.id);
+            if (viewerLayer) {
+              const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+              const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers');
+              if (cesiumIndex !== layerIndex && cesiumIndex >= 0) {
+                const diffIndex = cesiumIndex - layerIndex;
+                if (diffIndex < 0) {
+                  // Move layer up in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.raise(viewerLayer);
+                  }
+                } else if (diffIndex > 0) {
+                  // Move layer down in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.lower(viewerLayer);
+                  }
                 }
               }
             }
           }
-          }
         }
       } else if (lowerType === 'overlays') {
         for (const layer of layers) {
-        if (this.overlayLayerDataSourceGroup.has(layer.id)) {
-          const viewerLayer = this.overlayLayerDataSourceGroup.get(layer.id);
-          if (viewerLayer) {
-            const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
-            const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers') + this.getDataSourceLayersSize('layers');
-            if (cesiumIndex !== layerIndex && cesiumIndex >= 0){
-              const diffIndex = cesiumIndex - layerIndex;
-              if (diffIndex < 0) {
-                // Move layer up in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.raise(viewerLayer);
-                }
-              } else if (diffIndex > 0) {
-                // Move layer down in collection
-                for (let i = 0; i < Math.abs(diffIndex); i++) {
-                  dataSourceCollection.lower(viewerLayer);
+          if (this.overlayLayerDataSourceGroup.has(layer.id)) {
+            const viewerLayer = this.overlayLayerDataSourceGroup.get(layer.id);
+            if (viewerLayer) {
+              const cesiumIndex = dataSourceCollection.indexOf(viewerLayer);
+              const layerIndex = layers.indexOf(layer) + this.getDataSourceLayersSize('baselayers') + this.getDataSourceLayersSize('layers');
+              if (cesiumIndex !== layerIndex && cesiumIndex >= 0) {
+                const diffIndex = cesiumIndex - layerIndex;
+                if (diffIndex < 0) {
+                  // Move layer up in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.raise(viewerLayer);
+                  }
+                } else if (diffIndex > 0) {
+                  // Move layer down in collection
+                  for (let i = 0; i < Math.abs(diffIndex); i++) {
+                    dataSourceCollection.lower(viewerLayer);
+                  }
                 }
               }
             }
@@ -1151,7 +1152,6 @@ export class MapCesiumService {
         }
       }
     }
-  }
   }
 
 

--- a/projects/map-maplibre/package.json
+++ b/projects/map-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-maplibre",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,13 +21,13 @@
     "tslib": "^2.6.3",
     "maplibre-gl": "^5.24.0",
     "@mapbox/togeojson": "0.16.2",
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/services-layers": "16.0.0",
-    "@dlr-eoc/utilities": "16.0.0"
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
+    "@dlr-eoc/utilities": "16.0.1-next.0"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.0",
-    "@dlr-eoc/shared-assets": "16.0.0"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0"
   },
   "sideEffects": false
 }

--- a/projects/map-maplibre/src/lib/map-maplibre.component.ts
+++ b/projects/map-maplibre/src/lib/map-maplibre.component.ts
@@ -2,7 +2,7 @@ import { AfterViewChecked, AfterViewInit, Component, ElementRef, Input, NgZone, 
 import { Map as glMap, MapLibreEvent, NavigationControl, ScaleControl, StyleSpecification, StyleLayer, GeoJSONSource, Evented, addSourceType } from 'maplibre-gl';
 import { setExtent, setCenter, setZoom, getExtent, getAllLayers, getUkisLayerIDs, removeLayerAndSource, changeOrderOfLayers, setRotation, setPitch, getRotation, getUkisLayerMetadata, UKIS_METADATA } from './maplibre.helpers';
 
-import { MapState, MapStateService, WebMercator, WGS84 } from '@dlr-eoc/services-map-state';
+import { MapState, MapStateService, WebMercator, WGS84, TepsgCode } from '@dlr-eoc/services-map-state';
 import { LayersService, TFiltertypes, TFiltertypesUncap, Layer as ukisLayer } from '@dlr-eoc/services-layers';
 
 
@@ -243,12 +243,12 @@ export class MapMaplibreComponent implements OnInit, AfterViewInit, AfterViewChe
     // https://maplibre.org/maplibre-style-spec/projection/
     const projectionSpecType = this.map.getProjection()?.type;
     const projMapping = { globe: WGS84, mercator: WebMercator };
-    let epsg = projMapping.mercator;
-    if(Array.isArray(projectionSpecType)){
+    let epsg = projMapping.mercator as TepsgCode;
+    if (Array.isArray(projectionSpecType)) {
       // TODO: Perhaps this won't work in all cases.
-      epsg = projectionSpecType.pop() as string;
-    }else if(typeof projectionSpecType === 'string'){
-      epsg = projMapping[projectionSpecType];
+      epsg = projectionSpecType.pop() as TepsgCode;
+    } else if (typeof projectionSpecType === 'string') {
+      epsg = projMapping[projectionSpecType] as TepsgCode;
     }
 
     const newCenter = { lat: latLng.lat, lon: latLng.lng };

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-ol",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -17,9 +17,9 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/services-layers": "16.0.0",
-    "@dlr-eoc/utils-maps": "16.0.0",
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
+    "@dlr-eoc/utils-maps": "16.0.1-next.0",
     "ol": "^v10.9.0",
     "ol-mapbox-style": "^13.2.1",
     "proj4": "^2.20.8",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/base-layers-raster": "16.0.0",
-    "@dlr-eoc/shared-assets": "16.0.0"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0"
   }
 }

--- a/projects/map-ol/src/lib/map-ol.component.ts
+++ b/projects/map-ol/src/lib/map-ol.component.ts
@@ -3,8 +3,7 @@ import { Component, OnInit, ViewEncapsulation, Input, OnDestroy, AfterViewChecke
 
 
 
-import { IMapStateProjection, MapState } from '@dlr-eoc/services-map-state';
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { IMapStateProjection, MapState, MapStateService, TepsgCode } from '@dlr-eoc/services-map-state';
 import { Subscription } from 'rxjs';
 import { skip } from 'rxjs/operators';
 import { MapOlService } from './map-ol.service';
@@ -46,7 +45,7 @@ import VectorSource from 'ol/source/Vector';
 
 
 
- /** @see (control options object) https://github.com/openlayers/openlayers/tree/main/src/ol/control */
+/** @see (control options object) https://github.com/openlayers/openlayers/tree/main/src/ol/control */
 export interface IMapControls {
   /** for icon replacement use - label | collapseLabel */
   attribution?: boolean | object;
@@ -564,7 +563,7 @@ export class MapOlComponent implements OnInit, AfterViewInit, AfterViewChecked, 
       const extent = this.mapSvc.getCurrentExtent(true);
       const nativeExtent = this.mapSvc.getCurrentExtent(false);
       const rotation = this.mapSvc.getRotation();
-      const epsg = this.mapSvc.getProjection().getCode();
+      const epsg = this.mapSvc.getProjection().getCode() as TepsgCode;
 
       const newCenter = { lat: parseFloat(center[1]), lon: parseFloat(center[0]) };
       const ms = new MapState(zoom, newCenter, { notifier: 'map' }, extent, nativeExtent, oldMapState.time, oldMapState.viewAngle, rotation, epsg);

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -94,7 +94,7 @@ import { Subject } from 'rxjs';
 import { flattenLayers, layerOrGroupSetZIndex } from '@dlr-eoc/utils-maps';
 import LayerRenderer from 'ol/renderer/Layer';
 import VectorSource from 'ol/source/Vector';
-import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjFitOptions, TepsgCode } from '@dlr-eoc/services-map-state';
+import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjFitOptions, TepsgCode, adjustBBoxAxisToEnu } from '@dlr-eoc/services-map-state';
 
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes;
@@ -1289,6 +1289,19 @@ export class MapOlService {
     }
   }
 
+  /**
+   * nativeBbox: - nativeBbox.bbox
+   * bboxEpsg: - nativeBbox.epsg
+   */
+  private adjustBBoxEnuBeforeSetExtent(nativeBbox: TGeoExtent, bboxEpsg: TepsgCode) {
+    const proj = getProjection(bboxEpsg);
+    const code = proj?.getCode() as TepsgCode;
+    const axis = proj?.getAxisOrientation();
+    // https://github.com/openlayers/openlayers/issues/12406
+    // https://github.com/proj4js/proj4js/blob/main/lib/adjust_axis.js
+    return adjustBBoxAxisToEnu(nativeBbox as never, axis as never, code);
+  }
+
   /** use subdomains to setUrl/s on source */
   private setSubdomains(l: Layer, layer: olLayer<olSource>): void {
     if (l instanceof VectorLayer || l instanceof RasterLayer) {
@@ -1387,7 +1400,8 @@ export class MapOlService {
             const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
             gl.setExtent(extent);
           } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
-            gl.setExtent([...l.nativeBbox.bbox]);
+            const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(l.nativeBbox.bbox, l.nativeBbox.epsg as TepsgCode);
+            gl.setExtent([...adjustBBox]);
           }
         });
       } else {
@@ -1433,7 +1447,8 @@ export class MapOlService {
         const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
         layer.setExtent(extent);
       } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
-        layer.setExtent([...l.nativeBbox.bbox]);
+        const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(l.nativeBbox.bbox, l.nativeBbox.epsg as TepsgCode);
+        layer.setExtent([...adjustBBox]);
       }
 
       layer.setProperties(layeroptions);
@@ -2390,14 +2405,20 @@ export class MapOlService {
 
   /**
    *
-   * @param extent: [minX, minY, maxX, maxY]
+   * @param extent: [minX, minY, maxX, maxY] - can also be a nativeExtent where the axis order differs
    * @param geographic: boolean
    * @param fitOptions: olFitOptions
    * @returns olExtend: [minX, minY, maxX, maxY]
    */
   public setExtent(extent: TGeoExtent, geographic?: boolean, fitOptions?: olFitOptions): TGeoExtent {
-    const projection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
-    const transfomExtent = transformExtent(extent.slice(0, 4) as [number, number, number, number], projection, this.getProjection().getCode(), transformExtentStops);
+    const extentProjection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
+    const extentProjectionCode = extentProjection?.getCode() as TepsgCode || this.EPSG;
+
+    const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(extent.slice(0, 4) as TGeoExtent, extentProjectionCode);
+
+    const destinationProjectionCode = this.getProjection().getCode();
+    const destinationProjection = getProjection(destinationProjectionCode);
+    const transfomExtent = transformExtent(adjustBBox, extentProjection || this.EPSG, destinationProjection || destinationProjectionCode, transformExtentStops);
     const newFitOptions: olFitOptions = {
       size: this.map.getSize(),
       // padding: [100, 200, 100, 100] // Padding (in pixels) to be cleared inside the view. Values in the array are top, right, bottom and left padding. Default is [0, 0, 0, 0].
@@ -2660,7 +2681,25 @@ export class MapOlService {
     const currentExtent = layer.getExtent() as olExtent | undefined;
     // nativeBbox exists and matches newEpsg -> use nativeBbox
     if (nativeBbox && nativeBbox.epsg === newEpsg) {
-      layer.setExtent(nativeBbox.bbox);
+      const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(nativeBbox.bbox, nativeBbox.epsg)
+      layer.setExtent(adjustBBox);
+      return;
+    } else if (nativeBbox && nativeBbox.epsg !== newEpsg && !bbox) {
+      const hasbboxProReg = this.registeredProjections.has(nativeBbox.epsg);
+      // if nativeBbox exists but newEpsg is different then nativeBbox -> use transformExtent
+      if (hasbboxProReg) {
+        const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(nativeBbox.bbox, nativeBbox.epsg)
+        const ext = transformExtent(adjustBBox, nativeBbox.epsg, newEpsg, transformExtentStops);
+        layer.setExtent(ext);
+      } else {
+        // if nativeBbox epsg not registered -> try to transform old extent or clear extent
+        if (currentExtent) {
+          const ext = transformExtent(currentExtent, oldEpsg, newEpsg, transformExtentStops);
+          layer.setExtent(ext);
+        } else {
+          layer.setExtent(undefined);
+        }
+      }
       return;
     }
 
@@ -2693,7 +2732,7 @@ export class MapOlService {
         if (layer instanceof olLayer) {
           const newEpsg = projection?.code;
           this.reprojectVectorLayers(layer, oldEpsg, newEpsg);
-          this.setLayerExtentAfterProjection(layer, newEpsg);
+          this.setLayerExtentAfterProjection(layer, oldEpsg, newEpsg);
         } else {
           console.log(layer, 'no olLayer');
         }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -94,7 +94,7 @@ import { Subject } from 'rxjs';
 import { flattenLayers, layerOrGroupSetZIndex } from '@dlr-eoc/utils-maps';
 import LayerRenderer from 'ol/renderer/Layer';
 import VectorSource from 'ol/source/Vector';
-import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjFitOptions } from '@dlr-eoc/services-map-state';
+import { WebMercator, WGS84, EPSG_3857_Def, IProjDef, IProjFitOptions, TepsgCode } from '@dlr-eoc/services-map-state';
 
 
 declare type Tgroupfiltertype = TFiltertypesUncap | TFiltertypes;
@@ -121,7 +121,7 @@ export class MapOlService {
   public map: olMap; // ol.Map;
   public view: olView;
   private viewOptions: olViewOptions;
-  public EPSG: string;
+  public EPSG: TepsgCode;
   private hitTolerance = 0;
   private hitLayerCurr = null;
   private hitLayerPrev = null;
@@ -1041,7 +1041,7 @@ export class MapOlService {
     if (l instanceof WmtsLayer) {
 
       let tileGrid = this.getTileGrid<olWMTSTileGrid>('wmts');
-      let matrixSet = this.EPSG;
+      let matrixSet = this.EPSG as string;
       if (l.params.matrixSetOptions) {
         matrixSet = l.params.matrixSetOptions.matrixSet;
         if ('resolutions' in l.params.matrixSetOptions) {
@@ -2587,7 +2587,7 @@ export class MapOlService {
       }
       const oldView = this.map.getView();
       const oldProj = oldView.getProjection();
-      const oldEPSG = oldProj.getCode();
+      const oldEPSG = oldProj.getCode() as TepsgCode;
       const oldExtent = oldView.calculateExtent();
 
       // Test is not same projection
@@ -2600,7 +2600,7 @@ export class MapOlService {
 
           // https://openlayers.org/en/latest/examples/reprojection-by-code.html
           const view = new olView(viewOptions);
-          this.EPSG = view.getProjection().getCode();
+          this.EPSG = view.getProjection().getCode() as TepsgCode;
           this.map.setView(view);
           this.view = this.map.getView();
 
@@ -2640,7 +2640,7 @@ export class MapOlService {
   /**
    * reproject vector layers and set extent for all
    */
-  private reprojectVectorLayers(layer: olLayer, oldEpsg: string, newEpsg: string) {
+  private reprojectVectorLayers(layer: olLayer, oldEpsg: TepsgCode, newEpsg: TepsgCode) {
     let source = layer.getSource();
     // check for nested sources, e.g. cluster or cluster of clusters etc
     while (source['source']) {
@@ -2654,11 +2654,10 @@ export class MapOlService {
   /**
    * set or calculate the new layer extent after reprojectFeatures
    */
-  private setLayerExtentAfterProjection(layer: olLayer, newEpsg: string) {
+  private setLayerExtentAfterProjection(layer: olLayer, oldEpsg: TepsgCode, newEpsg: TepsgCode) {
     const bbox = layer.get('bbox') as number[] | undefined;
-    const nativeBbox = layer.get('nativeBbox') as | { epsg: string; bbox: TGeoExtent } | undefined;
+    const nativeBbox = layer.get('nativeBbox') as | { epsg: TepsgCode; bbox: TGeoExtent } | undefined;
     const currentExtent = layer.getExtent() as olExtent | undefined;
-
     // nativeBbox exists and matches newEpsg -> use nativeBbox
     if (nativeBbox && nativeBbox.epsg === newEpsg) {
       layer.setExtent(nativeBbox.bbox);
@@ -2688,7 +2687,7 @@ export class MapOlService {
   /**
    * reprojecting vector layers and set extent
    */
-  private adjustLayersAfterProjection(oldEpsg: string, projection: IProjDef) {
+  private adjustLayersAfterProjection(oldEpsg: TepsgCode, projection: IProjDef) {
     this.map.getLayers().getArray().forEach((layerGroup: olLayerGroup) => {
       layerGroup.getLayers().getArray().forEach(layer => {
         if (layer instanceof olLayer) {

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -2711,7 +2711,7 @@ export class MapOlService {
   public registerProjection(projDef: IProjDef) {
     const hasProj = this.registeredProjections.has(projDef.code);
     if (!hasProj) {
-      proj4.defs(projDef.code, projDef.proj4js);
+      proj4.defs(projDef.code, ('projjson' in projDef) ? projDef.projjson : projDef.proj4js);
       olRegister(proj4);
       this.registeredProjections.set(projDef.code, projDef);
     }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -1289,19 +1289,6 @@ export class MapOlService {
     }
   }
 
-  /**
-   * nativeBbox: - nativeBbox.bbox
-   * bboxEpsg: - nativeBbox.epsg
-   */
-  private adjustBBoxEnuBeforeSetExtent(nativeBbox: TGeoExtent, bboxEpsg: TepsgCode) {
-    const proj = getProjection(bboxEpsg);
-    const code = proj?.getCode() as TepsgCode;
-    const axis = proj?.getAxisOrientation();
-    // https://github.com/openlayers/openlayers/issues/12406
-    // https://github.com/proj4js/proj4js/blob/main/lib/adjust_axis.js
-    return adjustBBoxAxisToEnu(nativeBbox as never, axis as never, code);
-  }
-
   /** use subdomains to setUrl/s on source */
   private setSubdomains(l: Layer, layer: olLayer<olSource>): void {
     if (l instanceof VectorLayer || l instanceof RasterLayer) {
@@ -1400,8 +1387,7 @@ export class MapOlService {
             const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
             gl.setExtent(extent);
           } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
-            const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(l.nativeBbox.bbox, l.nativeBbox.epsg as TepsgCode);
-            gl.setExtent([...adjustBBox]);
+            gl.setExtent([...l.nativeBbox.bbox]);
           }
         });
       } else {
@@ -1447,8 +1433,7 @@ export class MapOlService {
         const extent = transformExtent(l.bbox.slice(0, 4) as [number, number, number, number], WGS84, currentProjection, transformExtentStops);
         layer.setExtent(extent);
       } else if (l.nativeBbox && l.nativeBbox.epsg === currentProjection) {
-        const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(l.nativeBbox.bbox, l.nativeBbox.epsg as TepsgCode);
-        layer.setExtent([...adjustBBox]);
+        layer.setExtent([...l.nativeBbox.bbox]);
       }
 
       layer.setProperties(layeroptions);
@@ -2412,13 +2397,9 @@ export class MapOlService {
    */
   public setExtent(extent: TGeoExtent, geographic?: boolean, fitOptions?: olFitOptions): TGeoExtent {
     const extentProjection = (geographic) ? getProjection(WGS84) : getProjection(this.EPSG);
-    const extentProjectionCode = extentProjection?.getCode() as TepsgCode || this.EPSG;
-
-    const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(extent.slice(0, 4) as TGeoExtent, extentProjectionCode);
-
     const destinationProjectionCode = this.getProjection().getCode();
     const destinationProjection = getProjection(destinationProjectionCode);
-    const transfomExtent = transformExtent(adjustBBox, extentProjection || this.EPSG, destinationProjection || destinationProjectionCode, transformExtentStops);
+    const transfomExtent = transformExtent(extent.slice(0, 4), extentProjection || this.EPSG, destinationProjection || destinationProjectionCode, transformExtentStops);
     const newFitOptions: olFitOptions = {
       size: this.map.getSize(),
       // padding: [100, 200, 100, 100] // Padding (in pixels) to be cleared inside the view. Values in the array are top, right, bottom and left padding. Default is [0, 0, 0, 0].
@@ -2681,15 +2662,13 @@ export class MapOlService {
     const currentExtent = layer.getExtent() as olExtent | undefined;
     // nativeBbox exists and matches newEpsg -> use nativeBbox
     if (nativeBbox && nativeBbox.epsg === newEpsg) {
-      const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(nativeBbox.bbox, nativeBbox.epsg)
-      layer.setExtent(adjustBBox);
+      layer.setExtent(nativeBbox.bbox);
       return;
     } else if (nativeBbox && nativeBbox.epsg !== newEpsg && !bbox) {
       const hasbboxProReg = this.registeredProjections.has(nativeBbox.epsg);
       // if nativeBbox exists but newEpsg is different then nativeBbox -> use transformExtent
       if (hasbboxProReg) {
-        const adjustBBox = this.adjustBBoxEnuBeforeSetExtent(nativeBbox.bbox, nativeBbox.epsg)
-        const ext = transformExtent(adjustBBox, nativeBbox.epsg, newEpsg, transformExtentStops);
+        const ext = transformExtent(nativeBbox.bbox, nativeBbox.epsg, newEpsg, transformExtentStops);
         layer.setExtent(ext);
       } else {
         // if nativeBbox epsg not registered -> try to transform old extent or clear extent

--- a/projects/map-three/package.json
+++ b/projects/map-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-three",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,10 +19,10 @@
     "@angular/core": "^21.2.14"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/services-layers": "16.0.0",
-    "@dlr-eoc/map-ol": "16.0.0",
-    "@dlr-eoc/utils-maps": "16.0.0",
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
+    "@dlr-eoc/map-ol": "16.0.1-next.0",
+    "@dlr-eoc/utils-maps": "16.0.1-next.0",
     "proj4": "^2.20.8",
     "tslib": "^2.6.3",
     "three": "^0.176.0"

--- a/projects/ngx-ukis-ui-clarity/package.json
+++ b/projects/ngx-ukis-ui-clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "description": "This project includes schematics to add a base UKIS-Layout to an angular application. The Layout is based on Clarity so [add this first](https://clarity.design/get-started/developing/angular)!",
   "keywords": [
     "schematics",
@@ -44,10 +44,10 @@
     "jsonc-parser": "^3.3.1",
     "ol": "^v10.9.0",
     "proj4": "^2.20.8",
-    "@dlr-eoc/services-layers": "16.0.0",
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0",
-    "@dlr-eoc/map-ol": "16.0.0"
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.0",
+    "@dlr-eoc/map-ol": "16.0.1-next.0"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {

--- a/projects/ngx-ukis-ui-clarity/src/lib/layerentry-group/layerentry-group.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/layerentry-group/layerentry-group.component.ts
@@ -69,9 +69,7 @@ export class LayerentryGroupComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
-    if (this.group.bbox && this.group.bbox.length >= 4) {
-      this.canZoomToGroup = true;
-    }
+    this.checkCanZoomToGroup();
 
     if (typeof this.group?.expanded === 'object') {
       if (Object.keys(EactiveTabs).includes(this.group.expanded.tab)) {
@@ -93,6 +91,14 @@ export class LayerentryGroupComponent implements OnInit {
   private setDefaultActiveTabs() {
     if (!this.group?.action) {
       this.activeTabs.settings = false;
+    }
+  }
+
+  checkCanZoomToGroup() {
+    if ((this.group.bbox && this.group.bbox.length >= 4) || (this.group.nativeBbox && this.mapState?.getMapState().value.proj.epsg === this.group.nativeBbox.epsg && this.group.nativeBbox.bbox.length >= 4)) {
+      this.canZoomToGroup = true;
+    } else {
+      this.canZoomToGroup = false;
     }
   }
 
@@ -209,6 +215,7 @@ export class LayerentryGroupComponent implements OnInit {
 
 
   showProperties() {
+    this.checkCanZoomToGroup();
     this.group.expanded = !this.group.expanded;
   }
 

--- a/projects/ngx-ukis-ui-clarity/src/lib/layerentry/layerentry.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/layerentry/layerentry.component.ts
@@ -21,10 +21,10 @@ enum EactiveTabs {
 type TactiveTabs = keyof typeof EactiveTabs;
 
 @Component({
-    selector: 'ukis-layerentry',
-    templateUrl: './layerentry.component.html',
-    styleUrls: ['./layerentry.component.scss'],
-    imports: [NgClass, ClrIcon, NgStyle, ClrCommonFormsModule, ClrRangeModule, FormsModule, ClrSelectModule, DynamicComponent]
+  selector: 'ukis-layerentry',
+  templateUrl: './layerentry.component.html',
+  styleUrls: ['./layerentry.component.scss'],
+  imports: [NgClass, ClrIcon, NgStyle, ClrCommonFormsModule, ClrRangeModule, FormsModule, ClrSelectModule, DynamicComponent]
 })
 export class LayerentryComponent implements OnInit {
   @HostBinding('class.layer-visible') get visible() { return this.layer.visible; }
@@ -44,6 +44,8 @@ export class LayerentryComponent implements OnInit {
   get expanded() {
     if (this.layer) {
       const layerExpanded = this.layer.expanded;
+      // can change after projection was set for nativeBbox
+      this.checkCanZoomToLayer();
       if (typeof layerExpanded === 'boolean') {
         return layerExpanded;
       } else {
@@ -164,11 +166,7 @@ export class LayerentryComponent implements OnInit {
       this.setDefaultActiveTabs();
     }
 
-
-    if (this.layer.bbox && this.layer.bbox.length >= 4) {
-      this.canZoomToLayer = true;
-    }
-
+    this.checkCanZoomToLayer()
 
     if (this.layer.filtertype === 'Baselayers' && !this.layer.legendImg && !this.layer.description && !this.layer.action && !this.layer.actions && !this.layer.styles && !(this.layer.styles?.length > 1)) {
       this.hasTabsbody = false;
@@ -182,6 +180,14 @@ export class LayerentryComponent implements OnInit {
 
     if (!this.layer.legendImg && !this.layer.description) {
       this.switchTab('settings');
+    }
+  }
+
+  checkCanZoomToLayer() {
+    if ((this.layer.bbox && this.layer.bbox.length >= 4) || (this.layer.nativeBbox && this.mapState?.getMapState().value.proj.epsg === this.layer.nativeBbox.epsg && this.layer.nativeBbox.bbox.length >= 4)) {
+      this.canZoomToLayer = true;
+    } else {
+      this.canZoomToLayer = false;
     }
   }
 
@@ -272,7 +278,7 @@ export class LayerentryComponent implements OnInit {
     }
   }
 
-  setLayerOpacity(layer) {
+  setLayerOpacity(layer: Layer) {
     if (!this.group) {
       this.layersSvc.updateLayer(layer, layer.filtertype || 'Layers'); // TODO check for baselayers!!!!!!
     } else {
@@ -318,7 +324,7 @@ export class LayerentryComponent implements OnInit {
     }
   }
 
-  hasActiveTabs(){
+  hasActiveTabs() {
     return Object.values(this.activeTabs).filter(v => v).length > 0;
   }
 

--- a/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/mouse-position/mouse-position.component.ts
@@ -5,7 +5,7 @@ import { distinctUntilChanged, Subscription } from 'rxjs';
 import { ClrSelectModule, ClrCommonFormsModule, ClrNumberInputModule } from '@clr/angular';
 
 import { FormsModule } from '@angular/forms';
-import { MapStateService } from '@dlr-eoc/services-map-state';
+import { MapStateService, TepsgCode } from '@dlr-eoc/services-map-state';
 
 interface ISelectProjection {
   title: string;
@@ -42,7 +42,7 @@ export class MousePositionComponent implements OnInit, OnDestroy {
     });
 
     this.mapProjection = this.mapSvc.getProjection();
-    this.setProjection(this.mapProjection.getCode());
+    this.setProjection(this.mapProjection.getCode() as TepsgCode);
 
     // TODO: remove listeneres on destry
     const onMove = this.mapSvc.map.on('pointermove', this.mapMoveSubscription);
@@ -52,7 +52,7 @@ export class MousePositionComponent implements OnInit, OnDestroy {
   /**
    * projLike: 'olProjection'
    */
-  setProjection(epsg: string) {
+  setProjection(epsg: TepsgCode) {
     if (epsg === 'EPSG:4326') {
       this.projections = [
         { title: epsg, value: epsg }

--- a/projects/ngx-ukis-utilities/package.json
+++ b/projects/ngx-ukis-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-utilities",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "description": "Angular utilities for @dlr-eoc ukis frontends",
   "keywords": [
     "angular",

--- a/projects/services-layers/package.json
+++ b/projects/services-layers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-layers",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.0",
-    "@dlr-eoc/shared-assets": "16.0.0"
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0"
   },
   "dependencies": {
     "tslib": "^2.6.3"

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -17,7 +17,8 @@
   "peerDependencies": {
     "@angular/common": "^21.2.14",
     "@angular/core": "^21.2.14",
-    "rxjs": "~7.8.2"
+    "rxjs": "~7.8.2",
+    "proj4": "^2.20.8"
   },
   "dependencies": {
     "@dlr-eoc/services-layers": "16.0.1-next.0",

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-map-state",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,7 +20,7 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -1,5 +1,5 @@
 import { TGeoExtent } from "@dlr-eoc/services-layers";
-import { EPSG_3857_Def, IProjDef, WebMercator } from "./projections";
+import { EPSG_3857_Def, IProjDef, WebMercator, TepsgCode } from "./projections";
 
 export interface IMapCenter {
   lat: number;
@@ -38,7 +38,7 @@ export interface IMapState {
 
 export interface IMapStateProjection {
   /** EPSG of current map projection */
-  epsg?: string;
+  epsg?: TepsgCode;
   fitOptions?: IProjFitOptions;
   IProjDef?: IProjDef;
 }
@@ -63,7 +63,7 @@ export class MapState implements IMapState {
   /** current map projection */
   proj: Required<Omit<IMapStateProjection, 'IProjDef'>>;
 
-  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg?: string, projFitOptions?: IProjFitOptions) {
+  constructor(zoom: number, center: IMapCenter, options?: IMapStateOptions, extent: TGeoExtent = [-180.0, -90.0, 180.0, 90.0], nativeExtent: TGeoExtent = EPSG_3857_Def.extent, time: string = new Date().toISOString(), viewAngle: number = 0, rotation: number = 0, epsg?: TepsgCode, projFitOptions?: IProjFitOptions) {
     const defaultOptions = {
       maxzoom: 0,
       minzoom: 0,

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -1,3 +1,5 @@
+import { ProjectionDefinition } from "proj4";
+
 /**
  * https://spatialreference.org/
  * https://github.com/proj4js/proj4js
@@ -5,14 +7,20 @@
  * https://epsg.org/
  * https://github.com/openlayers/openlayers/blob/main/src/ol/proj/Projection.js
  */
-export interface IProjDef {
+export type IProjDef = IProj4jsDef | IProjjDef;
+interface IProjDefBase {
     code: string; // e.g.: "EPSG:3857"
-    proj4js: string; // ' proj4 string, e.g.: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"
     title: string; // projection title shown on switch, e.g.: "Spherical Mercator",
     extent: [number, number, number, number]; // projection extent in projected coordinates, e.g.: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
     worldExtent: [number, number, number, number]; // projection extent in geographical coordinates, e.g.:[-180.0, -85.06, 180.0, 85.06],
     global: true | false; // whether is global or local projection
     units: 'radians' | 'degrees' | 'ft' | 'm' | 'pixels' | 'tile-pixels' | 'us-ft';
+}
+interface IProj4jsDef extends IProjDefBase {
+    proj4js: string; // ' proj4 string, e.g.: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"
+}
+interface IProjjDef extends IProjDefBase {
+    projjson: ProjectionDefinition; // projjson object https://github.com/proj4js/proj4js#using
 }
 
 export const WebMercator = 'EPSG:3857';
@@ -57,3 +65,14 @@ export const EPSG_4326_Def: IProjDef = {
     global: true,
     units: 'degrees'
 };
+
+export const EPSG_3035_Def: IProjDef = {
+    code: `EPSG:3035`,
+    title: 'ETRS89-extended / LAEA Europe',
+    proj4js: '+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs +axis=neu', // +axis=neu was missing in proj4js string!! 
+    // projjson: // https://spatialreference.org/ref/epsg/3035/projjson.json
+    extent: [1908523.29, 1137678.21, 6901611.5, 6872461.46], // EPSG.io
+    worldExtent: [-16.1, 33.26, 38.01, 84.73],
+    global: false,
+    units: 'm'
+}

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -1,5 +1,6 @@
 import { ProjectionDefinition } from "proj4";
 
+export type TepsgCode = `EPSG:${number}` | `ESRI:${number}`;
 /**
  * https://spatialreference.org/
  * https://github.com/proj4js/proj4js
@@ -9,7 +10,7 @@ import { ProjectionDefinition } from "proj4";
  */
 export type IProjDef = IProj4jsDef | IProjjDef;
 interface IProjDefBase {
-    code: string; // e.g.: "EPSG:3857"
+    code: TepsgCode; // e.g.: "EPSG:3857"
     title: string; // projection title shown on switch, e.g.: "Spherical Mercator",
     extent: [number, number, number, number]; // projection extent in projected coordinates, e.g.: [-20026376.39, -20048966.10, 20026376.39, 20048966.10],
     worldExtent: [number, number, number, number]; // projection extent in geographical coordinates, e.g.:[-180.0, -85.06, 180.0, 85.06],

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -160,7 +160,7 @@ export function adjustBBoxAxisToEnu(bbox: [number, number, number, number], axis
         return bbox;
     } else {
         const adjustBBox = adjustBBoxAxis(bbox, axis);
-        console.log('adjustBBoxAxis', bbox, axis, 'to', adjustBBox);
+        // console.log('adjustBBoxAxis', bbox, 'to axis', axis, adjustBBox);
         return adjustBBox;
     }
 }

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -1,4 +1,4 @@
-import { ProjectionDefinition } from "proj4";
+import proj4, { ProjectionDefinition } from "proj4";
 
 export type TepsgCode = `EPSG:${number}` | `ESRI:${number}`;
 /**
@@ -152,7 +152,14 @@ export function adjustBBoxAxis(bbox: [number, number, number, number], axis: Axi
 
 }
 
-export function adjustBBoxAxisToEnu(bbox: [number, number, number, number], axis?: AxisType, proj?: TepsgCode) {
+export function adjustBBoxAxisToEnu(bbox: [number, number, number, number], proj?: TepsgCode | IProjDef, axis?: AxisType) {
+    if (typeof proj === 'object') {
+        const proj4Axis = getProj4Defs(proj).axis;
+        if (proj4Axis) {
+            axis = proj4Axis as AxisType;
+        }
+    }
+
     if (!axis ||
         !proj ||
         proj &&
@@ -163,4 +170,13 @@ export function adjustBBoxAxisToEnu(bbox: [number, number, number, number], axis
         // console.log('adjustBBoxAxis', bbox, 'to axis', axis, adjustBBox);
         return adjustBBox;
     }
+}
+
+export function getProj4Defs(projDef: IProjDef) {
+    let projDefs = proj4.defs(projDef.code);
+    if (!projDefs) {
+        proj4.defs(projDef.code, ('projjson' in projDef) ? projDef.projjson : projDef.proj4js);
+        projDefs = proj4.defs(projDef.code);
+    }
+    return projDefs;
 }

--- a/projects/services-map-state/src/lib/types/projections.ts
+++ b/projects/services-map-state/src/lib/types/projections.ts
@@ -77,3 +77,90 @@ export const EPSG_3035_Def: IProjDef = {
     global: false,
     units: 'm'
 }
+
+
+interface AxisTransform {
+    eastIdx: number;    // Which index is East? (0 or 1)
+    northIdx: number;   // Which index is North? (0 or 1)
+    eastSign: number;   // 1 for East, -1 for West
+    northSign: number;  // 1 for North, -1 for South
+}
+type AxisType = 'enu' | 'ned' | 'neu' | 'uen' | 'esu' | 'wnu';
+/**
+ * Adjusts a Bounding Box [minX, minY, maxX, maxY] 
+ * based on the axis string (e.g., 'enu', 'ned').
+ * Target is always ENU (East, North).
+ * 
+ * **Definition | X-Axis | Y-Axis | Z-Axis**
+ * **`+axis=enu`** | **East** | **North** | **Up** | **The Standard.
+ * **`+axis=ned`** | **North** | **East** | **Down** 
+ * **`+axis=neu`** | **North** | **East** | **Up**
+ * **`+axis=uen`** | **Up** | **East** | **North**
+ * **`+axis=esu`** | **East** | **South** | **Up**
+ * **`+axis=wnu`** | **West** | **North** | **Up**
+ * 
+ * https://github.com/openlayers/openlayers/issues/12406
+ * https://github.com/proj4js/proj4js/blob/main/lib/adjust_axis.js
+ */
+export function adjustBBoxAxis(bbox: [number, number, number, number], axis: AxisType) {
+    const AXIS_MAP: Record<AxisType, AxisTransform> = {
+        // X=East, Y=North
+        'enu': { eastIdx: 0, northIdx: 1, eastSign: 1, northSign: 1 },
+        // X=North, Y=East
+        'ned': { eastIdx: 1, northIdx: 0, eastSign: 1, northSign: 1 },
+        'neu': { eastIdx: 1, northIdx: 0, eastSign: 1, northSign: 1 },
+        // X=Up, Y=East (Warning: North is the Z-axis here, not in the BBOX)
+        'uen': { eastIdx: 1, northIdx: 0, eastSign: 1, northSign: 1 },
+        // X=East, Y=South
+        'esu': { eastIdx: 0, northIdx: 1, eastSign: 1, northSign: -1 },
+        // X=West, Y=North
+        'wnu': { eastIdx: 0, northIdx: 1, eastSign: -1, northSign: 1 },
+    };
+
+    const config = (axis) ? AXIS_MAP[axis] : undefined;
+
+    if (!config) {
+        throw new Error(`Unsupported axis definition: ${axis}`);
+    }
+
+    const [minX, minY, maxX, maxY] = bbox;
+
+    // Helper to get the value and apply sign from the correct index
+    const getVal = (idx: number, sign: number, isMax: boolean) => {
+        const val = isMax ? (idx === 0 ? maxX : maxY) : (idx === 0 ? minX : minY);
+        return val * sign;
+    };
+
+    // Calculate the new East (X) and North (Y) values
+    const eastMin = getVal(config.eastIdx, config.eastSign, false);
+    const eastMax = getVal(config.eastIdx, config.eastSign, true);
+
+    const northMin = getVal(config.northIdx, config.northSign, false);
+    const northMax = getVal(config.northIdx, config.northSign, true);
+
+    /**
+     * CRITICAL: When multiplying by -1 (West or South), 
+     * the minimum value becomes the maximum value.
+     * We must use Math.min/max to ensure the BBOX remains valid.
+     */
+    return [
+        Math.min(eastMin, eastMax),
+        Math.min(northMin, northMax),
+        Math.max(eastMin, eastMax),
+        Math.max(northMin, northMax)
+    ] as [number, number, number, number];
+
+}
+
+export function adjustBBoxAxisToEnu(bbox: [number, number, number, number], axis?: AxisType, proj?: TepsgCode) {
+    if (!axis ||
+        !proj ||
+        proj &&
+        proj === WGS84 && axis === 'neu') {
+        return bbox;
+    } else {
+        const adjustBBox = adjustBBoxAxis(bbox, axis);
+        console.log('adjustBBoxAxis', bbox, axis, 'to', adjustBBox);
+        return adjustBBox;
+    }
+}

--- a/projects/services-ogc/package.json
+++ b/projects/services-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/services-ogc",
   "main": "src/public-api",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This module bundles our clients for OGC standards. E.g. parse OWS Context JSON, WMS, WMTS or WPS.",
@@ -20,11 +20,11 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.0",
-    "@dlr-eoc/services-util-store": "16.0.0",
-    "@dlr-eoc/base-layers-raster": "16.0.0",
-    "@dlr-eoc/services-map-state": "16.0.0",
-    "@dlr-eoc/utils-ogc": "16.0.0",
+    "@dlr-eoc/services-layers": "16.0.1-next.0",
+    "@dlr-eoc/services-util-store": "16.0.1-next.0",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.0",
+    "@dlr-eoc/services-map-state": "16.0.1-next.0",
+    "@dlr-eoc/utils-ogc": "16.0.1-next.0",
     "w3c-schemas": "^1.4.0",
     "ogc-schemas": "^2.6.1",
     "ol": "^v10.9.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/shared-assets": "16.0.0",
+    "@dlr-eoc/shared-assets": "16.0.1-next.0",
     "proj4": "^2.20.8",
     "terser": "^5.39.2"
   }

--- a/projects/services-util-store/package.json
+++ b/projects/services-util-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-util-store",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/shared-assets/package.json
+++ b/projects/shared-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/shared-assets",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "main": "index",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/utilities/package.json
+++ b/projects/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utilities",
   "main": "src/public-api",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities.",

--- a/projects/utils-browser/package.json
+++ b/projects/utils-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-browser",
   "main": "src/public-api",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities like download data as blob and Paper layout.",

--- a/projects/utils-maps/package.json
+++ b/projects/utils-maps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-maps",
   "main": "src/public-api",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities for OpenLayers and WebGL.",

--- a/projects/utils-ogc/package.json
+++ b/projects/utils-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-ogc",
   "main": "src/public-api",
-  "version": "16.0.0",
+  "version": "16.0.1-next.0",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library bundles our clients for OGC standards. The long-term-strategy is to make all services in `@dlr-eoc/services-ogc` independent of angular and move them here.",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
- `IProjDef` only supports `proj4js` and there axis definitions are sometimes missing.

## What is the new behavior?
- [feat(services-map-state): allow to use projjson in IProjDef](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/293/changes/296dc6fa31e9f8e87961c337996e928b04507792)
- [feat(map-ol): use projjson if in IProjDef](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/293/changes/75b82a04565a60f5bbb615ba2ce266aa233ea4d4)
- [feat(services-map-state): export function adjustBBoxAxis and adjustBBoxAxisToEnu](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/293/changes/c1c3ca7989de51a80a51e8b619da10bc56666c0f) for wms 1.3.0 bbox where axis are not in `enu` order.
- [fix(ngx-ukis-ui-clarity): can zoom to nativeBbox for LayerentryComponent and LayerentryGroupComponent](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/293/changes/2378cadf054ff884564b50940714e591669aca27)
- [refactor: use type TepsgCode for epsg codes](https://github.com/dlr-eoc/ukis-frontend-libraries/pull/293/changes/496c8fbc192db18673ff601cc2fd6ef1debc3878)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?

- `@dlr-eoc/services-map-state`
- `@dlr-eoc/ngx-ukis-ui-clarity`
- `@dlr-eoc/map-ol`
- `@dlr-eoc/map-maplibre`
- `@dlr-eoc/map-cesium`
- `demo-maps`
