### PR TITLE
Allow to config set map-ol view extent on setProjection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Use `projjson` or `proj4js` to create projection if defined on `IProjDef`.
  - Use all `IListMatrixSet` options in `getTileGrid` to create `WMTSTileGrid`.
  - Allow to pass `olViewOptions` to map-ol component.
+ - Use `IProjFitOptions.viewSetExtent` in `mapSvc.setProjection`.
 
 * **@dlr-eoc/services-layers:**
  - More options to create `WMTSTileGrid` on `IListMatrixSet`. The new optional options are `extent?: TGeoExtent`, `origin?: number[]`, `origins?: [number, number][]`, `tileSizes?: number[]` and `sizes?: [number, number][];`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * **@dlr-eoc/services-layers:**
  - More options to create `WMTSTileGrid` on `IListMatrixSet`. The new optional options are `extent?: TGeoExtent`, `origin?: number[]`, `origins?: [number, number][]`, `tileSizes?: number[]` and `sizes?: [number, number][];`.
 
+**@dlr-eoc/ngx-ukis-ui-clarity:**
+ - Input `setViewExtent` on `<ukis-projection-switch>` to configure if the `view.extent` is set on `mapSvc.setProjection` - Default `true` like before.
 
 * **@dlr-eoc/services-map-state:**
  - Add `IProjFitOptions.viewSetExtent` to configure if the `view.extent` is set on `mapSvc.setProjection`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * **@dlr-eoc/services-layers:**
  - More options to create `WMTSTileGrid` on `IListMatrixSet`. The new optional options are `extent?: TGeoExtent`, `origin?: number[]`, `origins?: [number, number][]`, `tileSizes?: number[]` and `sizes?: [number, number][];`.
 
+
+* **@dlr-eoc/services-map-state:**
+ - Add `IProjFitOptions.viewSetExtent` to configure if the `view.extent` is set on `mapSvc.setProjection`.
+
  
 ### Bug Fixes
 * **@dlr-eoc/ngx-ukis-ui-clarity:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ukis-frontend-libraries",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -22341,10 +22341,10 @@
     },
     "projects/base-layers-raster": {
       "name": "@dlr-eoc/base-layers-raster",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22355,10 +22355,10 @@
     },
     "projects/cookie-alert": {
       "name": "@dlr-eoc/cookie-alert",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-util-store": "16.0.1-next.2",
+        "@dlr-eoc/services-util-store": "16.0.1-next.3",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22371,13 +22371,13 @@
       }
     },
     "projects/demo-auth": {
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/cookie-alert": "16.0.1-next.2",
-        "@dlr-eoc/map-ol": "16.0.1-next.2",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.2"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/cookie-alert": "16.0.1-next.3",
+        "@dlr-eoc/map-ol": "16.0.1-next.3",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
@@ -22394,18 +22394,18 @@
       }
     },
     "projects/demo-maps": {
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/map-cesium": "16.0.1-next.2",
-        "@dlr-eoc/map-maplibre": "16.0.1-next.2",
-        "@dlr-eoc/map-ol": "16.0.1-next.2",
-        "@dlr-eoc/map-three": "16.0.1-next.2",
-        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.2",
-        "@dlr-eoc/services-ogc": "16.0.1-next.2",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2",
-        "@dlr-eoc/utils-maps": "16.0.1-next.2"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/map-cesium": "16.0.1-next.3",
+        "@dlr-eoc/map-maplibre": "16.0.1-next.3",
+        "@dlr-eoc/map-ol": "16.0.1-next.3",
+        "@dlr-eoc/map-three": "16.0.1-next.3",
+        "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.3",
+        "@dlr-eoc/services-ogc": "16.0.1-next.3",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3",
+        "@dlr-eoc/utils-maps": "16.0.1-next.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
@@ -22425,18 +22425,18 @@
     },
     "projects/map-cesium": {
       "name": "@dlr-eoc/map-cesium",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/engine": "^22.3.0",
         "@cesium/widgets": "^14.3.0",
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3"
       },
       "peerDependencies": {
         "@angular/common": "^21.2.14",
@@ -22446,19 +22446,19 @@
     },
     "projects/map-maplibre": {
       "name": "@dlr-eoc/map-maplibre",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
-        "@dlr-eoc/utilities": "16.0.1-next.2",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
+        "@dlr-eoc/utilities": "16.0.1-next.3",
         "@mapbox/togeojson": "0.16.2",
         "maplibre-gl": "^5.24.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2"
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3"
       },
       "peerDependencies": {
         "@angular/common": "^21.2.14",
@@ -22468,12 +22468,12 @@
     },
     "projects/map-ol": {
       "name": "@dlr-eoc/map-ol",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
-        "@dlr-eoc/utils-maps": "16.0.1-next.2",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
+        "@dlr-eoc/utils-maps": "16.0.1-next.3",
         "ol": "^v10.9.0",
         "ol-mapbox-style": "^13.2.1",
         "proj4": "^2.20.8",
@@ -22481,8 +22481,8 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2",
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22493,13 +22493,13 @@
     },
     "projects/map-three": {
       "name": "@dlr-eoc/map-three",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/map-ol": "16.0.1-next.2",
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
-        "@dlr-eoc/utils-maps": "16.0.1-next.2",
+        "@dlr-eoc/map-ol": "16.0.1-next.3",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
+        "@dlr-eoc/utils-maps": "16.0.1-next.3",
         "proj4": "^2.20.8",
         "three": "^0.176.0",
         "tslib": "^2.6.3"
@@ -22515,7 +22515,7 @@
     },
     "projects/ngx-ukis-ui-clarity": {
       "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular-devkit/core": "^21.2.13",
@@ -22539,10 +22539,10 @@
         "@angular/router": "^21.2.14",
         "@clr/angular": "^18.1.0",
         "@clr/ui": "^18.1.0",
-        "@dlr-eoc/map-ol": "16.0.1-next.2",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.2",
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
+        "@dlr-eoc/map-ol": "16.0.1-next.3",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.3",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
         "jsonc-parser": "^3.3.1",
         "ol": "^v10.9.0",
         "proj4": "^2.20.8",
@@ -22593,7 +22593,7 @@
     },
     "projects/ngx-ukis-utilities": {
       "name": "@dlr-eoc/ngx-ukis-utilities",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22607,15 +22607,15 @@
     },
     "projects/services-layers": {
       "name": "@dlr-eoc/services-layers",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.2",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2",
+        "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.3",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3",
         "zone.js": "~0.15.1"
       },
       "peerDependencies": {
@@ -22626,10 +22626,10 @@
     },
     "projects/services-map-state": {
       "name": "@dlr-eoc/services-map-state",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
@@ -22645,14 +22645,14 @@
     },
     "projects/services-ogc": {
       "name": "@dlr-eoc/services-ogc",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-        "@dlr-eoc/services-layers": "16.0.1-next.2",
-        "@dlr-eoc/services-map-state": "16.0.1-next.2",
-        "@dlr-eoc/services-util-store": "16.0.1-next.2",
-        "@dlr-eoc/utils-ogc": "16.0.1-next.2",
+        "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+        "@dlr-eoc/services-layers": "16.0.1-next.3",
+        "@dlr-eoc/services-map-state": "16.0.1-next.3",
+        "@dlr-eoc/services-util-store": "16.0.1-next.3",
+        "@dlr-eoc/utils-ogc": "16.0.1-next.3",
         "jsonix": "^3.0.0",
         "luxon": "^3.7.2",
         "ogc-schemas": "^2.6.1",
@@ -22663,7 +22663,7 @@
       },
       "devDependencies": {
         "@angular/platform-browser-dynamic": "^21.2.14",
-        "@dlr-eoc/shared-assets": "16.0.1-next.2",
+        "@dlr-eoc/shared-assets": "16.0.1-next.3",
         "proj4": "^2.20.8",
         "terser": "^5.39.2",
         "zone.js": "~0.15.1"
@@ -22676,7 +22676,7 @@
     },
     "projects/services-util-store": {
       "name": "@dlr-eoc/services-util-store",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",
@@ -22693,13 +22693,13 @@
     },
     "projects/shared-assets": {
       "name": "@dlr-eoc/shared-assets",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
     "projects/utilities": {
       "name": "@dlr-eoc/utilities",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -22711,7 +22711,7 @@
     },
     "projects/utils-browser": {
       "name": "@dlr-eoc/utils-browser",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/core": "^21.2.14",
@@ -22721,7 +22721,7 @@
     },
     "projects/utils-maps": {
       "name": "@dlr-eoc/utils-maps",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "delaunator": "^5.0.1",
@@ -22736,7 +22736,7 @@
     },
     "projects/utils-ogc": {
       "name": "@dlr-eoc/utils-ogc",
-      "version": "16.0.1-next.2",
+      "version": "16.0.1-next.3",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonix": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ukis-frontend-libraries",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "projectsScope": "@dlr-eoc/",

--- a/projects/base-layers-raster/package.json
+++ b/projects/base-layers-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/base-layers-raster",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -13,7 +13,7 @@
     "OSM"
   ],
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/cookie-alert/package.json
+++ b/projects/cookie-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/cookie-alert",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -16,7 +16,7 @@
     "@angular/core": "^21.2.14"
   },
   "dependencies": {
-    "@dlr-eoc/services-util-store": "16.0.1-next.2",
+    "@dlr-eoc/services-util-store": "16.0.1-next.3",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/demo-auth/package.json
+++ b/projects/demo-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-auth",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,10 +21,10 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.1-next.2",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.2",
-    "@dlr-eoc/cookie-alert": "16.0.1-next.2",
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2"
+    "@dlr-eoc/map-ol": "16.0.1-next.3",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.3",
+    "@dlr-eoc/cookie-alert": "16.0.1-next.3",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/package.json
+++ b/projects/demo-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-maps",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -22,15 +22,15 @@
     "proj4": "^2.20.8"
   },
   "dependencies": {
-    "@dlr-eoc/map-ol": "16.0.1-next.2",
-    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.2",
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-    "@dlr-eoc/map-three": "16.0.1-next.2",
-    "@dlr-eoc/utils-maps": "16.0.1-next.2",
-    "@dlr-eoc/services-ogc": "16.0.1-next.2",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2",
-    "@dlr-eoc/map-cesium": "16.0.1-next.2",
-    "@dlr-eoc/map-maplibre": "16.0.1-next.2"
+    "@dlr-eoc/map-ol": "16.0.1-next.3",
+    "@dlr-eoc/ngx-ukis-ui-clarity": "16.0.1-next.3",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+    "@dlr-eoc/map-three": "16.0.1-next.3",
+    "@dlr-eoc/utils-maps": "16.0.1-next.3",
+    "@dlr-eoc/services-ogc": "16.0.1-next.3",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3",
+    "@dlr-eoc/map-cesium": "16.0.1-next.3",
+    "@dlr-eoc/map-maplibre": "16.0.1-next.3"
   },
   "devDependencies": {
     "zone.js": "~0.15.1",

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.html
@@ -16,7 +16,7 @@
     <clr-vertical-nav-group-children class="padding title-ellipsis">
       On change, the map will fit to the new Projection extent. See "fitViewToNewExtent" Input
       <p></p>
-      <ukis-projection-switch [mapSvc]="mapSvc" [mapState]="mapStateSvc" [projectionList]="projections" [fitViewToNewExtent]="true"></ukis-projection-switch>
+      <ukis-projection-switch [mapSvc]="mapSvc" [mapState]="mapStateSvc" [projectionList]="projections" [fitViewToNewExtent]="projectionSwitchOptions.fitViewToNewExtent" [setViewExtent]="projectionSwitchOptions.setViewExtent"></ukis-projection-switch>
     </clr-vertical-nav-group-children>
   </clr-vertical-nav-group>
   <clr-vertical-nav-group [clrVerticalNavGroupExpanded]="true" class="layers" title="Coordinates">

--- a/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
+++ b/projects/demo-maps/src/app/route-components/route-example-projection/route-map2.component.ts
@@ -24,6 +24,11 @@ export class RouteMap2Component implements OnInit {
   @HostBinding('class') class = 'content-container';
   controls: IMapControls;
   viewOptions: olViewOptions;
+  public projectionSwitchOptions = {
+    fitViewToNewExtent: true,
+    setViewExtent: false // true -> nothing outside of the projection extent can be visible on the map.
+  }
+
   projections: IProjDef[];
 
   projectionSet = false;
@@ -39,7 +44,7 @@ export class RouteMap2Component implements OnInit {
     };
 
     this.viewOptions = {
-      showFullExtent: true
+      showFullExtent: false
     }
 
     const SwissCH1903: IProjDef = {
@@ -322,7 +327,7 @@ export class RouteMap2Component implements OnInit {
     const proJ = this.projections.find(p => p.title === 'Antarctic Polar Stereographic');
     if (proJ) {
       this.mapStateSvc.registerProjection(proJ);
-      this.mapStateSvc.setProjection(proJ.code, 'user', { fitToNativeBbox: nativeBbox });
+      this.mapStateSvc.setProjection(proJ.code, 'user', { fitToNativeBbox: nativeBbox, viewSetExtent: false });
     }
   }
 

--- a/projects/map-cesium/package.json
+++ b/projects/map-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-cesium",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,15 +19,15 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
     "@cesium/engine": "^22.3.0",
     "@cesium/widgets": "^14.3.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3"
   },
   "sideEffects": false
 }

--- a/projects/map-maplibre/package.json
+++ b/projects/map-maplibre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-maplibre",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,13 +21,13 @@
     "tslib": "^2.6.3",
     "maplibre-gl": "^5.24.0",
     "@mapbox/togeojson": "0.16.2",
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
-    "@dlr-eoc/utilities": "16.0.1-next.2"
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
+    "@dlr-eoc/utilities": "16.0.1-next.3"
   },
   "devDependencies": {
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3"
   },
   "sideEffects": false
 }

--- a/projects/map-ol/package.json
+++ b/projects/map-ol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-ol",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -17,9 +17,9 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
-    "@dlr-eoc/utils-maps": "16.0.1-next.2",
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
+    "@dlr-eoc/utils-maps": "16.0.1-next.3",
     "ol": "^v10.9.0",
     "ol-mapbox-style": "^13.2.1",
     "proj4": "^2.20.8",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2"
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3"
   }
 }

--- a/projects/map-ol/src/lib/map-ol.service.ts
+++ b/projects/map-ol/src/lib/map-ol.service.ts
@@ -2615,14 +2615,19 @@ export class MapOlService {
       const oldProj = oldView.getProjection();
       const oldEPSG = oldProj.getCode() as TepsgCode;
       const oldExtent = oldView.calculateExtent();
+      const viewSetExtent = (options?.viewSetExtent !== undefined) ? options.viewSetExtent : true;
 
       // Test is not same projection
       if (projIsReg.code !== oldProj.getCode()) {
         const newProjection = this.getOlProjection(projIsReg);
         if (newProjection) {
+          const fitExtent = newProjection.getExtent();
           viewOptions.projection = newProjection;
-          viewOptions.extent = newProjection.getExtent();
-          viewOptions.center = (viewOptions.extent) ? olExtGetCenter(viewOptions.extent) : viewOptions.center;
+          // nothing outside of this extent can be visible on the map. Can be problematic with showFullExtent=false
+          if (viewSetExtent) {
+            viewOptions.extent = fitExtent
+          }
+          viewOptions.center = (fitExtent) ? olExtGetCenter(fitExtent) : viewOptions.center;
 
           // https://openlayers.org/en/latest/examples/reprojection-by-code.html
           const view = new olView(viewOptions);
@@ -2631,7 +2636,7 @@ export class MapOlService {
           this.view = this.map.getView();
 
           if (options?.fitToProjectionExtent) {
-            this.view.fit(viewOptions.extent);
+            this.view.fit(fitExtent);
           } else {
             let newExtent: olExtent;
             if (options?.fitToBbox) {
@@ -2645,10 +2650,10 @@ export class MapOlService {
               newExtent = transformExtent(oldExtent, oldProj, newProjection, 8);
             }
 
-            if (containsExtent(viewOptions.extent, newExtent)) {
+            if (containsExtent(fitExtent, newExtent)) {
               this.view.fit(newExtent);
             } else {
-              this.view.fit(viewOptions.extent);
+              this.view.fit(fitExtent);
             }
           }
 

--- a/projects/map-three/package.json
+++ b/projects/map-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/map-three",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -19,10 +19,10 @@
     "@angular/core": "^21.2.14"
   },
   "dependencies": {
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
-    "@dlr-eoc/map-ol": "16.0.1-next.2",
-    "@dlr-eoc/utils-maps": "16.0.1-next.2",
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
+    "@dlr-eoc/map-ol": "16.0.1-next.3",
+    "@dlr-eoc/utils-maps": "16.0.1-next.3",
     "proj4": "^2.20.8",
     "tslib": "^2.6.3",
     "three": "^0.176.0"

--- a/projects/ngx-ukis-ui-clarity/package.json
+++ b/projects/ngx-ukis-ui-clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-ui-clarity",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "description": "This project includes schematics to add a base UKIS-Layout to an angular application. The Layout is based on Clarity so [add this first](https://clarity.design/get-started/developing/angular)!",
   "keywords": [
     "schematics",
@@ -44,10 +44,10 @@
     "jsonc-parser": "^3.3.1",
     "ol": "^v10.9.0",
     "proj4": "^2.20.8",
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.2",
-    "@dlr-eoc/map-ol": "16.0.1-next.2"
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.3",
+    "@dlr-eoc/map-ol": "16.0.1-next.3"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {

--- a/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
+++ b/projects/ngx-ukis-ui-clarity/src/lib/projection-switch/projection-switch.component.ts
@@ -22,6 +22,7 @@ export class ProjectionSwitchComponent implements OnInit {
   @Input('mapState') mapState: MapStateService;
   @Input('projectionList') projList: IProjDef[];
   @Input('fitViewToNewExtent') fitViewToNewExtent? = false;
+  @Input('setViewExtent') setViewExtent? = true;
   subscription: Subscription;
   selectedProj: IProjDef;
   constructor() { }
@@ -36,7 +37,7 @@ export class ProjectionSwitchComponent implements OnInit {
   setNewProjection(projection: IProjDef) {
     const currentEpsg = this.mapSvc.getProjection().getCode();
     if (currentEpsg !== projection.code) {
-      this.mapState.setProjection(projection, 'user', { fitToProjectionExtent: this.fitViewToNewExtent });
+      this.mapState.setProjection(projection, 'user', { fitToProjectionExtent: this.fitViewToNewExtent, viewSetExtent: this.setViewExtent });
     }
     this.selectedProj = projection;
   }

--- a/projects/ngx-ukis-utilities/package.json
+++ b/projects/ngx-ukis-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/ngx-ukis-utilities",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "description": "Angular utilities for @dlr-eoc ukis frontends",
   "keywords": [
     "angular",

--- a/projects/services-layers/package.json
+++ b/projects/services-layers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-layers",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.2",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2"
+    "@dlr-eoc/ngx-ukis-utilities": "16.0.1-next.3",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3"
   },
   "dependencies": {
     "tslib": "^2.6.3"

--- a/projects/services-map-state/package.json
+++ b/projects/services-map-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-map-state",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",
@@ -21,7 +21,7 @@
     "proj4": "^2.20.8"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/projects/services-map-state/src/lib/types/map-state.ts
+++ b/projects/services-map-state/src/lib/types/map-state.ts
@@ -16,6 +16,7 @@ export interface IProjFitOptions {
   fitToProjectionExtent?: boolean
   fitToBbox?: TGeoExtent
   fitToNativeBbox?: TGeoExtent
+  viewSetExtent?: boolean // default true
 }
 
 export interface IMapState {

--- a/projects/services-ogc/package.json
+++ b/projects/services-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/services-ogc",
   "main": "src/public-api",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This module bundles our clients for OGC standards. E.g. parse OWS Context JSON, WMS, WMTS or WPS.",
@@ -20,11 +20,11 @@
     "rxjs": "~7.8.2"
   },
   "dependencies": {
-    "@dlr-eoc/services-layers": "16.0.1-next.2",
-    "@dlr-eoc/services-util-store": "16.0.1-next.2",
-    "@dlr-eoc/base-layers-raster": "16.0.1-next.2",
-    "@dlr-eoc/services-map-state": "16.0.1-next.2",
-    "@dlr-eoc/utils-ogc": "16.0.1-next.2",
+    "@dlr-eoc/services-layers": "16.0.1-next.3",
+    "@dlr-eoc/services-util-store": "16.0.1-next.3",
+    "@dlr-eoc/base-layers-raster": "16.0.1-next.3",
+    "@dlr-eoc/services-map-state": "16.0.1-next.3",
+    "@dlr-eoc/utils-ogc": "16.0.1-next.3",
     "w3c-schemas": "^1.4.0",
     "ogc-schemas": "^2.6.1",
     "ol": "^v10.9.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "zone.js": "~0.15.1",
     "@angular/platform-browser-dynamic": "^21.2.14",
-    "@dlr-eoc/shared-assets": "16.0.1-next.2",
+    "@dlr-eoc/shared-assets": "16.0.1-next.3",
     "proj4": "^2.20.8",
     "terser": "^5.39.2"
   }

--- a/projects/services-util-store/package.json
+++ b/projects/services-util-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/services-util-store",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "src/public-api",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/shared-assets/package.json
+++ b/projects/shared-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlr-eoc/shared-assets",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "main": "index",
   "license": "Apache-2.0",
   "author": "Team UKIS",

--- a/projects/utilities/package.json
+++ b/projects/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utilities",
   "main": "src/public-api",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities.",

--- a/projects/utils-browser/package.json
+++ b/projects/utils-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-browser",
   "main": "src/public-api",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities like download data as blob and Paper layout.",

--- a/projects/utils-maps/package.json
+++ b/projects/utils-maps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-maps",
   "main": "src/public-api",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library contains a collection of utilities for OpenLayers and WebGL.",

--- a/projects/utils-ogc/package.json
+++ b/projects/utils-ogc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlr-eoc/utils-ogc",
   "main": "src/public-api",
-  "version": "16.0.1-next.2",
+  "version": "16.0.1-next.3",
   "license": "Apache-2.0",
   "author": "Team UKIS",
   "description": "This library bundles our clients for OGC standards. The long-term-strategy is to make all services in `@dlr-eoc/services-ogc` independent of angular and move them here.",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The Project is [building and passes all tests](https://github.com/dlr-eoc/ukis-frontend-libraries/blob/main/DEVELOPMENT.md#further-you-can-test-and-build-locally) without errors


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the new behavior?
If a projection is set in map-ol, you can specify whether or not the view should be restricted to the extent area, using `IProjFitOptions.viewSetExtent`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Is it part of one/more [packages](https://github.com/dlr-eoc/ukis-frontend-libraries/packages) and which?
- `@dlr-eoc/map-ol`
- `dlr-eoc/ngx-ukis-ui-clarity`
- `@dlr-eoc/services-map-state`